### PR TITLE
Feature/act obj freq

### DIFF
--- a/backend/src/core/event_object_frequencies/histogram_builder.rs
+++ b/backend/src/core/event_object_frequencies/histogram_builder.rs
@@ -1,0 +1,59 @@
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::HashMap;
+use process_mining::OCEL;
+
+
+#[derive(Serialize)]
+struct HistogramEntry {
+    event_type: String,
+    object_type: String,
+    histogram: HashMap<String, usize>, // string keys for JSON
+}
+
+#[derive(Serialize)]
+struct HistogramResult {
+    histograms: Vec<HistogramEntry>,
+}
+
+fn build_object_index(log: &OCEL) -> HashMap<&str, &str> {
+    log.objects
+        .iter()
+        .map(|obj| (obj.id.as_str(), obj.object_type.as_str()))
+        .collect()
+}
+
+pub fn build_event_object_histograms(log: &OCEL) -> Value {
+    let object_index = build_object_index(log);
+    let mut stats: HashMap<(String, String), HashMap<usize, usize>> = HashMap::new();
+
+    for event in &log.events {
+        let mut objects_by_type: HashMap<&str, usize> = HashMap::new();
+
+        for rel in &event.relationships {
+            if let Some(&otype) = object_index.get(rel.object_id.as_str()) {
+                *objects_by_type.entry(otype).or_insert(0) += 1;
+            }
+        }
+
+        for (otype, count) in objects_by_type {
+            let key = (event.event_type.clone(), otype.to_string());
+            let histogram = stats.entry(key).or_insert_with(HashMap::new);
+            *histogram.entry(count).or_insert(0) += 1;
+        }
+    }
+
+    let histograms = stats.into_iter().map(|((etype, otype), hist)| {
+        HistogramEntry {
+            event_type: etype,
+            object_type: otype,
+            histogram: hist.into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect(),
+        }
+    }).collect();
+
+    let result = HistogramResult { histograms };
+
+    serde_json::to_value(&result).unwrap()
+}

--- a/backend/src/core/event_object_frequencies/histogram_builder.rs
+++ b/backend/src/core/event_object_frequencies/histogram_builder.rs
@@ -28,6 +28,37 @@ fn build_object_index(log: &OCEL) -> HashMap<&str, &str> {
         .collect()
 }
 
+/*
+Example JSON output: 
+one histogram per (event_type, object_type) pair
+    - histogram x: count
+    - histogram y: frequency
+
+{
+  "histograms": [
+    {
+      "event_type": "Depart",
+      "object_type": "Container",
+      "histogram": [
+        { "count": 2, "frequency": 5 },
+        { "count": 3, "frequency": 2 },
+        { "count": 5, "frequency": 1 }
+      ]
+    },
+    {
+      "event_type": "Arrive",
+      "object_type": "Truck",
+      "histogram": [
+        { "count": 1, "frequency": 7 },
+        { "count": 2, "frequency": 4 }
+      ]
+    }
+  ]
+}
+
+*/
+
+
 pub fn build_event_object_histograms(log: &OCEL) -> Value {
     let object_index = build_object_index(log);
     let mut stats: HashMap<(String, String), HashMap<usize, usize>> = HashMap::new();

--- a/backend/src/core/event_object_frequencies/histogram_filtering.rs
+++ b/backend/src/core/event_object_frequencies/histogram_filtering.rs
@@ -1,0 +1,133 @@
+use serde::Deserialize;
+use process_mining::OCEL;
+
+/// JSON structs for deserializing the user selection
+#[derive(Deserialize)]
+struct Selection {
+    name: Option<String>,
+    filters: Vec<Filter>,
+}
+
+#[derive(Deserialize)]
+struct Filter {
+    event_type: String,
+    object_type: String,
+    ranges: Vec<[usize; 2]>, // list of [min, max] intervals
+}
+
+#[derive(Deserialize)]
+struct SelectionPayload {
+    selections: Vec<Selection>,
+}
+
+/* 
+Example JSON input: 
+one selection per output OCEL
+    - name could be used for filename
+    - each selection has multiple filters
+    - each filter specifies (event_type, object_type, ranges)
+    - treated as WHITELIST: keep events that match at least one range per filter
+
+{
+  "selections": [
+    {
+      "name": "small_trucks_and_depart_containers",
+      "filters": [
+        {
+          "event_type": "Arrive",
+          "object_type": "Truck",
+          "ranges": [[1, 1], [3, 3]]   // keep events with 1 or 2 trucks
+        },
+        {
+          "event_type": "Depart",
+          "object_type": "Container",
+          "ranges": [[2, 3]]           // keep events with 2–3 containers
+        }
+      ]
+    }
+  ]
+}
+
+  */
+
+/// Returns a Vec of filtered OCELs according to the user selection JSON
+pub fn filter_ocel_histograms(log: &OCEL, filters_json: &str) -> Vec<OCEL> {
+    // 1. Deserialize the JSON payload
+    let payload: SelectionPayload = serde_json::from_str(filters_json)
+        .expect("Invalid JSON for filters");
+
+    // 2. Precompute object_id -> object_type map
+    let object_index: std::collections::HashMap<&str, &str> = log.objects
+        .iter()
+        .map(|obj| (obj.id.as_str(), obj.object_type.as_str()))
+        .collect();
+
+    let mut result: Vec<OCEL> = Vec::new();
+
+    // 3. Iterate over selections
+    for selection in payload.selections {
+        let mut filtered_events: Vec<_> = Vec::new();
+
+        // 3a. Iterate over all events in the log
+        'event_loop: for event in &log.events {
+            // Check if event matches any filter in this selection
+            for filter in &selection.filters {
+                if event.event_type != filter.event_type {
+                    continue; // skip filters that don’t match this event type
+                }
+
+                // Count objects of the given object_type
+                let mut object_count = 0;
+                for rel in &event.relationships {
+                    if let Some(&otype) = object_index.get(rel.object_id.as_str()) {
+                        if otype == filter.object_type {
+                            object_count += 1;
+                        }
+                    }
+                }
+
+                // Check if object_count falls in any of the ranges
+                let mut matched = false;
+                for range in &filter.ranges {
+                    if object_count >= range[0] && object_count <= range[1] {
+                        matched = true;
+                        break;
+                    }
+                }
+
+                if !matched {
+                    continue 'event_loop; // skip this event
+                }
+            }
+
+            // Event passed all filters in this selection
+            filtered_events.push(event.clone());
+        }
+
+        // 4. Filter objects: keep only objects that appear in the filtered events
+        let mut used_objects: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for event in &filtered_events {
+            for rel in &event.relationships {
+                used_objects.insert(rel.object_id.as_str());
+            }
+        }
+
+        let filtered_objects: Vec<_> = log.objects
+            .iter()
+            .filter(|obj| used_objects.contains(obj.id.as_str()))
+            .cloned()
+            .collect();
+
+        // 5. Create filtered OCEL
+        let filtered_ocel = OCEL {
+            event_types: log.event_types.clone(),
+            object_types: log.object_types.clone(),
+            events: filtered_events,
+            objects: filtered_objects,
+        };
+
+        result.push(filtered_ocel);
+    }
+
+    result
+}

--- a/backend/src/core/event_object_frequencies/mod.rs
+++ b/backend/src/core/event_object_frequencies/mod.rs
@@ -1,0 +1,1 @@
+pub mod histogram_builder;

--- a/backend/src/core/event_object_frequencies/mod.rs
+++ b/backend/src/core/event_object_frequencies/mod.rs
@@ -1,1 +1,2 @@
 pub mod histogram_builder;
+pub mod histogram_filtering;

--- a/backend/src/core/mod.rs
+++ b/backend/src/core/mod.rs
@@ -2,3 +2,4 @@ pub mod df2_miner;
 pub mod ocel1_to_ocel2_converter;
 pub mod conformance;
 pub mod utils;
+pub mod event_object_frequencies;

--- a/backend/src/handlers/event_object_frequencies.rs
+++ b/backend/src/handlers/event_object_frequencies.rs
@@ -1,8 +1,10 @@
-use crate::core::event_object_frequencies::histogram_builder::build_event_object_histograms;
+use crate::core::event_object_frequencies::{histogram_builder::build_event_object_histograms, histogram_filtering::filter_ocel_histograms};
+
 
 use tokio::fs as tokio_fs;
 use axum::{
     extract::Path as AxumPath,
+    extract::Json as AxumJson,
     http::StatusCode,
     response::IntoResponse,
 };
@@ -38,4 +40,53 @@ pub async fn get_event_object_frequencies(AxumPath(ocel_file_id): AxumPath<Strin
     let histogram = build_event_object_histograms(&ocel);
 
     (StatusCode::OK, axum::Json(histogram)).into_response()
+}
+
+
+/// POST /v1/ocel_filter/:file_id
+/// Body: JSON following the `SelectionPayload` scheme
+/// Returns: array of filtered OCELs
+pub async fn post_ocel_filter(
+    AxumPath(ocel_file_id): AxumPath<String>,
+    AxumJson(selection_json): AxumJson<serde_json::Value>,
+) -> impl IntoResponse {
+    let ocel_path = format!("./temp/ocel_v2_{}.json", ocel_file_id);
+
+    // 1. Load the OCEL
+    let ocel_data: String = match tokio_fs::read_to_string(&ocel_path).await {
+        Ok(s) => s,
+        Err(e) => {
+            return (
+                StatusCode::NOT_FOUND,
+                format!("OCEL not found at {}: {}", ocel_path, e),
+            )
+                .into_response()
+        }
+    };
+
+    let ocel: OCEL = match serde_json::from_str(&ocel_data) {
+        Ok(o) => o,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("Failed to parse OCEL JSON ({}): {}", ocel_path, e),
+            )
+                .into_response()
+        }
+    };
+
+    // 2. Call filtering function
+    let filtered_ocels = match serde_json::to_string(&selection_json) {
+        Ok(json_str) => filter_ocel_histograms(&ocel, &json_str),
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("Failed to serialize selection JSON: {}", e),
+            )
+                .into_response()
+        }
+    };
+
+    // 3. Return JSON array of filtered OCELs
+    (StatusCode::OK, axum::Json(filtered_ocels)).into_response()
 }

--- a/backend/src/handlers/event_object_frequencies.rs
+++ b/backend/src/handlers/event_object_frequencies.rs
@@ -1,0 +1,41 @@
+use crate::core::event_object_frequencies::histogram_builder::build_event_object_histograms;
+
+use tokio::fs as tokio_fs;
+use axum::{
+    extract::Path as AxumPath,
+    http::StatusCode,
+    response::IntoResponse,
+};
+use crate::models::ocel::OCEL;
+
+/// GET /v1/event_object_frequencies/:file_id
+/// -> loads ./temp/ocpt_{file_id}.json and ./temp/ocel_{file_id}.json
+pub async fn get_event_object_frequencies(AxumPath(ocel_file_id): AxumPath<String>) -> impl IntoResponse {
+    let ocel_path = format!("./temp/ocel_v2_{}.json", ocel_file_id);
+
+    let ocel_data: String = match tokio_fs::read_to_string(&ocel_path).await {
+        Ok(s) => s,
+        Err(e) => {
+            return (
+                StatusCode::NOT_FOUND,
+                format!("OCEL not found at {}: {}", ocel_path, e),
+            )
+                .into_response()
+        }
+    };
+
+    let ocel: OCEL = match serde_json::from_str(&ocel_data) {
+        Ok(o) => o,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("Failed to parse OCEL JSON ({}): {}", ocel_path, e),
+            )
+                .into_response()
+        }
+    };
+
+    let histogram = build_event_object_histograms(&ocel);
+
+    (StatusCode::OK, axum::Json(histogram)).into_response()
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,3 +1,4 @@
 pub mod ocel;
 pub mod ocpt;
 pub mod conformance;
+pub mod event_object_frequencies;

--- a/backend/src/routes/v1/event_object_frequencies.rs
+++ b/backend/src/routes/v1/event_object_frequencies.rs
@@ -7,5 +7,6 @@ use crate::handlers::event_object_frequencies::{get_event_object_frequencies};
 pub fn router() -> Router {
     Router::new()
         .route("/ocel/{file_id}", get(get_event_object_frequencies))
+        .route("/ocel_filter/{file_id}", post(post_ocel_filter))
         
 }

--- a/backend/src/routes/v1/event_object_frequencies.rs
+++ b/backend/src/routes/v1/event_object_frequencies.rs
@@ -1,0 +1,11 @@
+use axum::{
+    Router,
+    routing::get,
+};
+use crate::handlers::event_object_frequencies::{get_event_object_frequencies};
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/ocel/{file_id}", get(get_event_object_frequencies))
+        
+}

--- a/backend/src/routes/v1/event_object_frequencies.rs
+++ b/backend/src/routes/v1/event_object_frequencies.rs
@@ -1,8 +1,8 @@
 use axum::{
     Router,
-    routing::get,
+    routing::{get, post},
 };
-use crate::handlers::event_object_frequencies::{get_event_object_frequencies};
+use crate::handlers::event_object_frequencies::{get_event_object_frequencies, post_ocel_filter};
 
 pub fn router() -> Router {
     Router::new()

--- a/backend/src/routes/v1/mod.rs
+++ b/backend/src/routes/v1/mod.rs
@@ -1,6 +1,7 @@
 pub mod upload;
 pub mod objects;
 pub mod conformance;
+pub mod event_object_frequencies;
 use axum::Router;
 
 
@@ -10,4 +11,5 @@ pub fn router() -> Router {
         .nest("/upload", upload::router())
         .nest("/objects", objects::router())
         .nest("/conformance", conformance::router())
+        .nest("/event_object_frequencies", event_object_frequencies::router())
 }


### PR DESCRIPTION
- create event-object histograms from OCEL
- based on filter JSON: create filtered version(s) of given OCELs

proposed JSON structure in respective src/core/event_object_frequencies/ files

please focus on the routing / the handler as i have never done this :)