### PR TITLE
Post ocpt

### DIFF
--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -2,3 +2,4 @@ pub mod ocel;
 pub mod ocpt;
 pub mod conformance;
 pub mod event_object_frequencies;
+pub mod upload;

--- a/backend/src/handlers/ocel.rs
+++ b/backend/src/handlers/ocel.rs
@@ -92,17 +92,17 @@ pub async fn post_ocel_binary(mut multipart: Multipart) -> impl IntoResponse {
 
     while let Some(field) = multipart.next_field().await.unwrap() {
         match field.name().unwrap_or("") {
-            "id" => {
+            "file_id" => {
                 let v = field.text().await.unwrap_or_default();
                 println!("📌 fileId: {v}");
                 file_id = Some(v);
             }
-            "data" => {
+            "file" => {
                 let data = field.bytes().await.unwrap_or_default();
                 println!("📥 file bytes: {}", data.len());
                 file_bytes = Some(data);
             }
-            "type" => {
+            "file_type" => {
                 file_type = Some(field.text().await.unwrap_or_default());
             }
             other => println!("⚠️ Unknown form field: {other}"),

--- a/backend/src/handlers/ocel.rs
+++ b/backend/src/handlers/ocel.rs
@@ -15,7 +15,7 @@ use chrono::Utc;
 use bytes::Bytes;
 use serde_json::Value;
 use std::path::Path as FsPath;
-use crate::core::ocel1_to_ocel2_converter::converter;
+use crate::core::struct_converters::{self, ocel_1_ocel_2_converter};
 use crate::models::ocel::OCEL;
 
 
@@ -42,7 +42,7 @@ pub async fn post_ocel_json(Json(payload): Json<Value>) -> impl IntoResponse {
 
     // Normalize into OCEL (v2 struct)
     let ocel_struct: OCEL = if is_ocel_v1(&payload) {
-        match converter::convert_ocel1_value_to_ocel(&payload) {
+        match ocel_1_ocel_2_converter::convert_ocel1_value_to_ocel(&payload) {
             Ok(oc) => oc,
             Err(e) => {
                 eprintln!("❌ v1→v2 conversion failed: {e:?}");
@@ -88,18 +88,22 @@ pub async fn post_ocel_json(Json(payload): Json<Value>) -> impl IntoResponse {
 pub async fn post_ocel_binary(mut multipart: Multipart) -> impl IntoResponse {
     let mut file_id: Option<String> = None;
     let mut file_bytes: Option<Bytes> = None;
+    let mut file_type: Option<String> = None;
 
     while let Some(field) = multipart.next_field().await.unwrap() {
         match field.name().unwrap_or("") {
-            "fileId" => {
+            "id" => {
                 let v = field.text().await.unwrap_or_default();
                 println!("📌 fileId: {v}");
                 file_id = Some(v);
             }
-            "file" => {
+            "data" => {
                 let data = field.bytes().await.unwrap_or_default();
                 println!("📥 file bytes: {}", data.len());
                 file_bytes = Some(data);
+            }
+            "type" => {
+                file_type = Some(field.text().await.unwrap_or_default());
             }
             other => println!("⚠️ Unknown form field: {other}"),
         }
@@ -133,7 +137,7 @@ pub async fn post_ocel_binary(mut multipart: Multipart) -> impl IntoResponse {
 
     // Normalize into OCEL (v2 struct)
     let ocel_struct: OCEL = if is_ocel_v1(&value) {
-        match converter::convert_ocel1_value_to_ocel(&value) {
+        match ocel_1_ocel_2_converter::convert_ocel1_value_to_ocel(&value) {
             Ok(oc) => oc,
             Err(e) => {
                 eprintln!("❌ v1→v2 conversion failed: {e:?}");

--- a/backend/src/handlers/ocpt.rs
+++ b/backend/src/handlers/ocpt.rs
@@ -5,19 +5,129 @@ use axum::{
     extract::Path,
     response::Response,
 };
+use crate::models::ocpt2::OCPT;
+use axum_extra::extract::Multipart; 
+use serde_json;
 use std::path::PathBuf;
 use tokio::fs;
 use serde::Deserialize;
 use serde_json::Value;
 use std::path::Path as FsPath;
 use crate::core::df2_miner::ocpt_generator::generate_ocpt_from_fileid;
+use crate::core::struct_converters::ocpt_frontend_backend::frontend_to_backend;
+use crate::models::ocpt::Ocpt;
 
 
 
 
-pub async fn post_ocpt_bin() {
+pub async fn post_ocpt(mut multipart: Multipart) -> Response {
+    let mut file_id: Option<String> = None;
+    let mut file_bytes: Option<bytes::Bytes> = None;
 
+    // --- extract multipart fields ---
+    while let Some(field) = match multipart.next_field().await {
+        Ok(f) => f,
+        Err(e) => {
+            return (StatusCode::BAD_REQUEST, format!("Malformed multipart: {e}")).into_response()
+        }
+    } {
+        match field.name().unwrap_or("") {
+            "id" => file_id = Some(field.text().await.unwrap_or_default()),
+            "data"   => file_bytes = Some(field.bytes().await.unwrap_or_default()),
+            _ => {}
+        }
+    }
 
+    let (id, bytes) = match (file_id, file_bytes) {
+        (Some(i), Some(b)) if !i.is_empty() && !b.is_empty() => (i, b),
+        _ => return (StatusCode::BAD_REQUEST, "Missing file or fileId").into_response(),
+    };
+
+    // --- parse JSON ---
+    let text = match str::from_utf8(&bytes) {
+        Ok(t) => t,
+        Err(e) => return (StatusCode::BAD_REQUEST, format!("File not UTF-8: {e}")).into_response(),
+    };
+    let value: Value = match serde_json::from_str(text) {
+        Ok(v) => v,
+        Err(e) => return (StatusCode::BAD_REQUEST, format!("Invalid JSON: {e}")).into_response(),
+    };
+
+    // --- ensure ./temp exists ---
+    if let Err(e) = ensure_temp_dir().await {
+        return (StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to prepare storage: {e}"))
+            .into_response();
+    }
+
+    // --- normalize to backend OCPT ---
+    // 1) Try backend shape directly
+    let ocpt_backend: OCPT = match serde_json::from_value::<OCPT>(value.clone()) {
+        Ok(be) => be,
+        Err(be_err) => {
+            // 2) Fallback: try frontend shape and convert
+            match serde_json::from_value::<Ocpt>(value.clone()) {
+                Ok(front) => match frontend_to_backend(front) {
+                    Ok(be) => be,
+                    Err(conv_err) => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            format!("Failed to convert FE OCPT -> BE OCPT: {conv_err}"),
+                        )
+                            .into_response()
+                    }
+                },
+                Err(fe_err) => {
+                    // Neither backend nor frontend matched
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        format!(
+                            "Unknown OCPT structure (not backend nor frontend). \
+                             Backend parse error: {be_err}; Frontend parse error: {fe_err}"
+                        ),
+                    )
+                        .into_response()
+                }
+            }
+        }
+    };
+
+    // --- persist normalized backend OCPT ---
+    let path = format!("./temp/ocpt_{id}.json");
+    let pretty = match serde_json::to_string_pretty(&ocpt_backend) {
+        Ok(s) => s,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Serialize OCPT failed: {e}"),
+            )
+                .into_response()
+        }
+    };
+    if let Err(e) = fs::write(&path, pretty).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to save OCPT: {e}"),
+        )
+            .into_response();
+    }
+
+    // --- response ---
+    let resp = serde_json::json!({
+        "status": "ok",
+        "kind": "ocpt",
+        "normalized": true,
+        "saved_as": path,
+        "is_valid": ocpt_backend.is_valid(),
+    });
+    (StatusCode::OK, Json(resp)).into_response()
+}
+
+async fn ensure_temp_dir() -> std::io::Result<()> {
+    let dir = PathBuf::from("./temp");
+    if !dir.exists() {
+        fs::create_dir_all(&dir).await?;
+    }
+    Ok(())
 }
 
 pub async fn get_ocpt(Path(file_id): Path<String>) -> impl IntoResponse {

--- a/backend/src/handlers/ocpt.rs
+++ b/backend/src/handlers/ocpt.rs
@@ -32,8 +32,8 @@ pub async fn post_ocpt(mut multipart: Multipart) -> Response {
         }
     } {
         match field.name().unwrap_or("") {
-            "id" => file_id = Some(field.text().await.unwrap_or_default()),
-            "data"   => file_bytes = Some(field.bytes().await.unwrap_or_default()),
+            "file_id" => file_id = Some(field.text().await.unwrap_or_default()),
+            "file"   => file_bytes = Some(field.bytes().await.unwrap_or_default()),
             _ => {}
         }
     }

--- a/backend/src/handlers/upload.rs
+++ b/backend/src/handlers/upload.rs
@@ -1,0 +1,58 @@
+use axum::{
+    Router,
+    routing::{get, post},
+    Json,
+    extract::{Query},
+    http::StatusCode,
+    response::IntoResponse,
+    extract::Path,
+};
+use axum_extra::extract::Multipart; 
+
+use crate::handlers::ocel::{post_ocel_binary};
+use crate::handlers::ocpt::{post_ocpt};
+use bytes::Bytes;
+
+/// Dispatch upload depending on the `fileType` form field.
+/// - If `fileType == "ocel"` → calls `post_ocel_binary`
+/// - If `fileType == "ocpt"` → calls `post_ocpt_binary`
+/// - Otherwise returns 400.
+pub async fn post_upload(mut multipart: Multipart) -> impl IntoResponse {
+    let mut file_id: Option<String> = None;
+    let mut file_bytes: Option<Bytes> = None;
+    let mut file_type: Option<String> = None;
+
+    while let Some(field) = multipart.next_field().await.unwrap() {
+        match field.name().unwrap_or("") {
+            "id" => {
+                let v = field.text().await.unwrap_or_default();
+                println!("📌 fileId: {v}");
+                file_id = Some(v);
+            }
+            "data" => {
+                let data = field.bytes().await.unwrap_or_default();
+                println!("📥 file bytes: {}", data.len());
+                file_bytes = Some(data);
+            }
+            "type" => {
+                file_type = Some(field.text().await.unwrap_or_default());
+            }
+            other => println!("⚠️ Unknown form field: {other}"),
+        }
+    }
+
+    match file_type.as_deref() {
+        Some("ocel") => post_ocel_binary(multipart).await.into_response(),
+        Some("ocpt") => post_ocpt(multipart).await.into_response(),
+        Some(other) => (
+            StatusCode::BAD_REQUEST,
+            format!("Unknown fileType: {}", other),
+        )
+            .into_response(),
+        None => (
+            StatusCode::BAD_REQUEST,
+            "Missing fileType field".to_string(),
+        )
+            .into_response(),
+    }
+}

--- a/backend/src/routes/v1/upload.rs
+++ b/backend/src/routes/v1/upload.rs
@@ -5,13 +5,17 @@ use axum::{
 
 };
 use crate::handlers::ocel::{post_ocel_binary,test_post_handler,test_get_handler};
+use crate::handlers::upload::{post_upload};
+use crate::handlers::ocpt::{post_ocpt};
 
 pub fn router() -> Router {
     Router::new()
         //.route("/", post(post_ocel_binary))
         //.route("/", get(get_ocel))
         .route("/", post(test_post_handler))
-        .route("/test", post(post_ocel_binary).layer(DefaultBodyLimit::max(50_000 * 1024)),)
+        .route("/ocel", post(post_ocel_binary).layer(DefaultBodyLimit::max(50_000 * 1024)),)
         .route("/", get(test_get_handler))
+        .route("/general", post(post_upload).layer(DefaultBodyLimit::max(50_000 * 1024)),)
+        .route("/ocpt", post(post_ocpt).layer(DefaultBodyLimit::max(50_000 * 1024)),)
         
 }


### PR DESCRIPTION
Added POST ocpt and general Upload post.

post_ocpt:
Takes in either the ocpt from the frontend json type (which we use for the display of the ocpt) or the backend ocpt type which is the struct from rust4pm. Then it converts/stores it into rust4pm struct type in the temp folder (so we don't store the frontend struct)
I also adjusted some paths in the routing accordingly to the changes in the frontend.
I also tested the post ocpt in the frontend and everything works for me.

Don't worry about the changes in the new upload handler. This will be deleted since once you read a multipart object you can't pass it to another function so the match case where we check what kind of file will be upload will move to the frontend.