### PR TITLE
filters event- and objectTypes

### DIFF
--- a/backend/src/core/event_object_frequencies/histogram_filtering.rs
+++ b/backend/src/core/event_object_frequencies/histogram_filtering.rs
@@ -1,5 +1,6 @@
 use process_mining::OCEL;
 use serde::Deserialize;
+use rustc_hash::FxHashSet;
 
 /// JSON structs for deserializing the user selection
 #[derive(Deserialize)]
@@ -79,6 +80,7 @@ pub fn filter_ocel_histograms(log: &OCEL, filters_json: &str) -> Vec<OCEL> {
     // 3. Iterate over selections
     for selection in payload.selections {
         let mut filtered_events: Vec<_> = Vec::new();
+        let mut filtered_event_types = FxHashSet::default();
 
         // 3a. Iterate over all events in the log
         'event_loop: for event in &log.events {
@@ -114,10 +116,15 @@ pub fn filter_ocel_histograms(log: &OCEL, filters_json: &str) -> Vec<OCEL> {
 
             // Event passed all filters in this selection
             filtered_events.push(event.clone());
+            // if event type is not in the set, add it
+            if !filtered_event_types.contains(&event.event_type)  {
+                filtered_event_types.insert(event.event_type.clone());
+            }
         }
 
         // 4. Filter objects: keep only objects that appear in the filtered events
         let mut used_objects: std::collections::HashSet<&str> = std::collections::HashSet::new();
+
         for event in &filtered_events {
             for rel in &event.relationships {
                 used_objects.insert(rel.object_id.as_str());
@@ -131,10 +138,25 @@ pub fn filter_ocel_histograms(log: &OCEL, filters_json: &str) -> Vec<OCEL> {
             .cloned()
             .collect();
 
+        let mut filtered_object_types = FxHashSet::default();
+        
+        for obj in &filtered_objects {
+            if !filtered_object_types.contains(&obj.object_type) {
+                filtered_object_types.insert(obj.object_type.clone());
+            }
+        }
+
+
         // 5. Create filtered OCEL
         let filtered_ocel = OCEL {
-            event_types: log.event_types.clone(),
-            object_types: log.object_types.clone(),
+            event_types: log.event_types.iter()
+                .filter(|et| filtered_event_types.contains(&et.name))
+                .cloned()
+                .collect(),
+            object_types: log.object_types.iter()
+                .filter(|ot| filtered_object_types.contains(&ot.name))
+                .cloned()
+                .collect(),
             events: filtered_events,
             objects: filtered_objects,
         };


### PR DESCRIPTION
fixes #64 , i.e. instead of just copying event- and objectTypes from the original ocel, they are now filtered s.t. they match the events and objects

tested manually (temporarily merged @ekansh18 's branch colors-integration into this and inspected the resulting ocel files/log graphs)

however, this will only properly work on main, once @ekansh18 's colors-integration branch is also merged.