### PR TITLE
add all_event_types to resource miner response

### DIFF
--- a/backend/src/handlers/resource_miner.rs
+++ b/backend/src/handlers/resource_miner.rs
@@ -15,6 +15,7 @@ pub struct ObjectNotResourceArc {
 pub struct ResourceMinerResponse {
     pub object_type_not_resource: Vec<String>,
     pub object_resource: Vec<String>,
+    pub all_event_types: Vec<String>,
     pub event_types_without_object_resource: Vec<String>,
     pub object_not_resource_arcs: Vec<ObjectNotResourceArc>,
     pub special_activity: Vec<String>,
@@ -133,8 +134,10 @@ pub async fn get_resource_miner(
     // Converting sets to arrays for JSON response
     let mut object_resource: Vec<String> = object_resource.into_iter().collect();
     let mut object_type_not_resource: Vec<String> = object_type_not_resource.into_iter().collect();
+    let mut all_event_types = all_activities;
 
     // Sorting arrays for deterministic JSON response
+    all_event_types.sort();
     object_resource.sort();
     object_type_not_resource.sort();
     special_activity.sort();
@@ -149,6 +152,7 @@ pub async fn get_resource_miner(
     let response = ResourceMinerResponse {
         object_type_not_resource,
         object_resource,
+        all_event_types,
         event_types_without_object_resource,
         object_not_resource_arcs,
         special_activity,

--- a/backend/src/handlers/resource_miner.rs
+++ b/backend/src/handlers/resource_miner.rs
@@ -15,7 +15,7 @@ pub struct ObjectNotResourceArc {
 pub struct ResourceMinerResponse {
     pub object_type_not_resource: Vec<String>,
     pub object_resource: Vec<String>,
-    pub all_event_types: Vec<String>,
+    pub non_special_event_types: Vec<String>,
     pub event_types_without_object_resource: Vec<String>,
     pub object_not_resource_arcs: Vec<ObjectNotResourceArc>,
     pub special_activity: Vec<String>,
@@ -131,13 +131,19 @@ pub async fn get_resource_miner(
         .cloned()
         .collect();
 
+    // non_special_event_types should exclude special activities.
+    let special_activity_set: FxHashSet<&String> = special_activity.iter().collect();
+    let mut non_special_event_types: Vec<String> = all_activities
+        .into_iter()
+        .filter(|activity| !special_activity_set.contains(activity))
+        .collect();
+
     // Converting sets to arrays for JSON response
     let mut object_resource: Vec<String> = object_resource.into_iter().collect();
     let mut object_type_not_resource: Vec<String> = object_type_not_resource.into_iter().collect();
-    let mut all_event_types = all_activities;
 
     // Sorting arrays for deterministic JSON response
-    all_event_types.sort();
+    non_special_event_types.sort();
     object_resource.sort();
     object_type_not_resource.sort();
     special_activity.sort();
@@ -152,7 +158,7 @@ pub async fn get_resource_miner(
     let response = ResourceMinerResponse {
         object_type_not_resource,
         object_resource,
-        all_event_types,
+        non_special_event_types,
         event_types_without_object_resource,
         object_not_resource_arcs,
         special_activity,


### PR DESCRIPTION
Adds `non_special_event_types` to the resource miner response.

This field was added based on a frontend request.

`non_special_event_types` contains event types present in the log excluding special_activity event types.

No mining logic was changed; only the response payload was extended/adjusted for frontend consumption.

### Updated response structure
```json
{
  "object_type_not_resource": ["string"],
  "object_resource": ["string"],
  "non_special_event_types": ["string"],
  "event_types_without_object_resource": ["string"],
  "object_not_resource_arcs": [
    {
      "source_type": "string",
      "target_type": "string"
    }
  ],
  "special_activity": ["string"]
}