### PR TITLE
Feature/special activities backend

### DIFF
--- a/backend/src/core/mod.rs
+++ b/backend/src/core/mod.rs
@@ -4,5 +4,6 @@ pub mod event_object_frequencies;
 pub mod identity_relations;
 pub mod ocim;
 pub mod ocpn_conversion;
+pub mod resource_miner;
 pub mod struct_converters;
 pub mod utils;

--- a/backend/src/core/resource_miner/main.rs
+++ b/backend/src/core/resource_miner/main.rs
@@ -1,0 +1,124 @@
+// Classifies all object types and activities in the OCEL into resource / non-resource categories.
+//
+// Definitions:
+//   resource     : an object type that is divergent in every activity it participates in
+//   non-resource : an object type that is NOT divergent in at least one activity
+//   special activity: an activity where ALL related object types are divergent 
+
+use crate::core::resource_miner::is_special_activity;
+use crate::models::ocel::{OCEL, OCELUtils};
+use crate::models::resource_miner::{ObjectNotResourceArc, ResourceMinerResponse};
+use axum::http::StatusCode;
+use rustc_hash::FxHashSet;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+pub fn build_resource_miner_response(
+    ocel: &OCEL,
+) -> Result<ResourceMinerResponse, (StatusCode, String)> {
+    let (divergence, _convergence, related, _deficiency) =
+        catch_unwind(AssertUnwindSafe(|| ocel.get_interaction_patterns())).map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to compute interaction patterns".to_string(),
+            )
+        })?;
+
+    let all_activities: Vec<String> = ocel.event_types.iter().map(|ev| ev.name.clone()).collect();
+    let all_object_types: Vec<String> =
+        ocel.object_types.iter().map(|ot| ot.name.clone()).collect();
+
+    // Object type is a resource only if it is divergent in every activity it appears in.
+    let mut object_resource: FxHashSet<String> = FxHashSet::default();
+    for object_type in &all_object_types {
+        let related_activities: Vec<&String> = related
+            .iter()
+            .filter_map(|(activity, related_object_types)| {
+                if related_object_types.contains(object_type) {
+                    Some(activity)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if related_activities.is_empty() {
+            continue;
+        }
+
+        let is_resource = related_activities.iter().all(|activity| {
+            divergence
+                .get(*activity)
+                .map(|div| div.contains(object_type))
+                .unwrap_or(false)
+        });
+
+        if is_resource {
+            object_resource.insert(object_type.clone());
+        }
+    }
+
+    // Each (object_type, activity) pair where the type is non-divergent becomes an arc.
+    let mut object_type_not_resource: FxHashSet<String> = FxHashSet::default();
+    let mut object_not_resource_arcs: Vec<ObjectNotResourceArc> = Vec::new();
+
+    for activity in &all_activities {
+        let related_object_types = related.get(activity).cloned().unwrap_or_default();
+        for object_type in related_object_types {
+            let is_divergent = divergence
+                .get(activity)
+                .map(|div| div.contains(&object_type))
+                .unwrap_or(false);
+
+            if !is_divergent {
+                object_type_not_resource.insert(object_type.clone());
+                object_not_resource_arcs.push(ObjectNotResourceArc {
+                    source_type: object_type,
+                    target_type: activity.clone(),
+                });
+            }
+        }
+    }
+
+    let mut special_activity: Vec<String> = all_activities
+        .iter()
+        .filter(|activity| is_special_activity(&divergence, &related, activity))
+        .cloned()
+        .collect();
+
+    // Activities where every related object type is a non-resource.
+    let mut event_types_without_object_resource: Vec<String> = all_activities
+        .iter()
+        .filter(|activity| {
+            if let Some(related_object_types) = related.get(*activity) {
+                !related_object_types.is_empty()
+                    && related_object_types
+                        .iter()
+                        .all(|object_type| !object_resource.contains(object_type))
+            } else {
+                false
+            }
+        })
+        .cloned()
+        .collect();
+
+    let mut object_resource: Vec<String> = object_resource.into_iter().collect();
+    let mut object_type_not_resource: Vec<String> = object_type_not_resource.into_iter().collect();
+
+    object_resource.sort();
+    object_type_not_resource.sort();
+    special_activity.sort();
+    event_types_without_object_resource.sort();
+    object_not_resource_arcs.sort_by(|left, right| {
+        left.source_type
+            .cmp(&right.source_type)
+            .then(left.target_type.cmp(&right.target_type))
+    });
+
+    Ok(ResourceMinerResponse {
+        object_type_not_resource,
+        object_resource,
+        event_types_without_object_resource,
+        object_not_resource_arcs,
+        special_activity,
+    })
+}

--- a/backend/src/core/resource_miner/main.rs
+++ b/backend/src/core/resource_miner/main.rs
@@ -127,6 +127,6 @@ pub fn build_resource_miner_response(
         non_special_event_types,
         event_types_without_object_resource,
         object_not_resource_arcs,
-        special_activity,
+        special_activities: special_activity,
     })
 }

--- a/backend/src/core/resource_miner/mod.rs
+++ b/backend/src/core/resource_miner/mod.rs
@@ -1,0 +1,87 @@
+// Shared helpers and public API re-exports for the resource_miner module.
+//
+// Sub-modules:
+//   - main.rs   : classifies object types as resource / non-resource and detects if there are special activities
+//   - special.rs: finds non-diverging object type combinations and creates/attaches silent objects
+
+use crate::models::ocel::{OCEL, OCELUtils};
+use axum::http::StatusCode;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::BTreeMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+mod main;
+mod special;
+
+pub use main::build_resource_miner_response;
+pub use special::{build_non_diverging_combinations_response, fix_multiple_special_activities};
+
+// (divergence map, related map) pair returned by get_interaction_patterns.
+// divergence: activity -> object types that are divergent for that activity
+// related   : activity -> object types that appear in at least one of its events
+pub(crate) type InteractionPatterns = (
+    FxHashMap<String, FxHashSet<String>>,
+    FxHashMap<String, FxHashSet<String>>,
+);
+
+// An activity is "special" when every object type related to it is divergent.
+pub(crate) fn is_special_activity(
+    divergence: &FxHashMap<String, FxHashSet<String>>,
+    related: &FxHashMap<String, FxHashSet<String>>,
+    activity: &str,
+) -> bool {
+    if let Some(related_object_types) = related.get(activity) {
+        !related_object_types.is_empty()
+            && related_object_types.iter().all(|object_type| {
+                divergence
+                    .get(activity)
+                    .map(|div| div.contains(object_type))
+                    .unwrap_or(false)
+            })
+    } else {
+        false
+    }
+}
+
+// Confirms the activity exists, has related object types, and is special.
+// Returns the interaction patterns and sorted related type names on success.
+// Errors: 404 if no related types, 400 if not a special activity.
+pub(crate) fn validate_special_activity_and_related(
+    ocel: &OCEL,
+    activity: &str,
+) -> Result<(InteractionPatterns, Vec<String>), (StatusCode, String)> {
+    let (divergence, _convergence, related, _deficiency) =
+        catch_unwind(AssertUnwindSafe(|| ocel.get_interaction_patterns())).map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to compute interaction patterns".to_string(),
+            )
+        })?;
+
+    let related_object_types_set = related.get(activity).cloned().unwrap_or_default();
+    if related_object_types_set.is_empty() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("Activity '{}' has no related object types", activity),
+        ));
+    }
+
+    if !is_special_activity(&divergence, &related, activity) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("Activity '{}' is not a special activity", activity),
+        ));
+    }
+
+    let related_object_types: Vec<String> = related_object_types_set.into_iter().collect();
+    Ok(((divergence, related), related_object_types))
+}
+
+// Builds a map from object ID to its type name.
+// Used to resolve the type of objects referenced in event relationships.
+pub(crate) fn build_object_id_to_type(ocel: &OCEL) -> BTreeMap<String, String> {
+    ocel.objects
+        .iter()
+        .map(|object| (object.id.clone(), object.object_type.clone()))
+        .collect()
+}

--- a/backend/src/core/resource_miner/special.rs
+++ b/backend/src/core/resource_miner/special.rs
@@ -135,6 +135,25 @@ pub async fn fix_multiple_special_activities(
     let mut no_combination_found: Vec<String> = Vec::new();
     let mut registry = SilentObjectRegistry::new();
 
+    // Snapshot ALL special activities in the original OCEL before any fixes are applied.
+    // We intentionally collect from the full `related` map (not just the request list) so
+    // that activities like "pick item" — which were special but not requested — are still
+    // captured and can appear in `resolved_by_cascade` if a fix resolves them indirectly.
+    let initially_special: FxHashSet<String> = {
+        let (divergence, _convergence, related, _deficiency) =
+            catch_unwind(AssertUnwindSafe(|| ocel.get_interaction_patterns())).map_err(|_| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to compute interaction patterns".to_string(),
+                )
+            })?;
+        related
+            .keys()
+            .filter(|a| is_special_activity(&divergence, &related, a))
+            .cloned()
+            .collect()
+    };
+
     for activity in activities {
         // Recompute each iteration: fixing a previous activity modifies the OCEL,
         // which can change divergence patterns for subsequent activities.
@@ -150,7 +169,10 @@ pub async fn fix_multiple_special_activities(
             related.get(activity.as_str()).cloned().unwrap_or_default();
 
         if related_types_set.is_empty() || !is_special_activity(&divergence, &related, activity) {
-            skipped_not_special.push(activity.clone());
+            if !initially_special.contains(activity.as_str()) {
+                skipped_not_special.push(activity.clone());
+            }
+            // If it was originally special, it will be captured in resolved_by_cascade below.
             continue;
         }
 
@@ -211,12 +233,35 @@ pub async fn fix_multiple_special_activities(
         });
     }
 
+    // After all fixes, recompute patterns on the final OCEL.
+    // Any activity that was originally special but is no longer special now — and was not
+    // explicitly fixed — was resolved as a side-effect of another fix (cascade).
+    // This covers both activities that were in the request list and those that were not.
+    let (final_divergence, _final_convergence, final_related, _final_deficiency) =
+        catch_unwind(AssertUnwindSafe(|| ocel.get_interaction_patterns())).map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to compute final interaction patterns".to_string(),
+            )
+        })?;
+    let fixed_set: FxHashSet<&str> = fixed.iter().map(|f| f.activity.as_str()).collect();
+    let mut resolved_by_cascade: Vec<String> = initially_special
+        .iter()
+        .filter(|a| {
+            !fixed_set.contains(a.as_str())
+                && !is_special_activity(&final_divergence, &final_related, a)
+        })
+        .cloned()
+        .collect();
+    resolved_by_cascade.sort();
+
     let new_file_id = ocel.export_to_path().await?;
     Ok(FixMultipleSpecialActivitiesResponse {
         source_file_id: source_file_id.to_string(),
         new_file_id,
         fixed,
         skipped_not_special,
+        resolved_by_cascade,
         no_combination_found,
     })
 }
@@ -337,8 +382,13 @@ fn generate_type_combinations_of_size(types: &[String], size: usize) -> Vec<Vec<
     combinations
 }
 
-// Builds a snake_case silent type name from the combination's type names only (no activity).
-// Example: ["employees", "products"] -> "silent_employees_products"
+// Builds a silent type name from the combination's type names only (no activity).
+// Each type name is reduced to a compact alphanumeric token (spaces and punctuation stripped),
+// then the tokens are joined with "_".
+// Examples:
+//   ["employees", "products"]      -> "silent_employees_products"
+//   ["Customer", "Order", "Item"]  -> "silent_customer_order_item"
+//   ["Customer", "Order Item"]     -> "silent_customer_orderitem"   (no collision with above)
 fn build_silent_object_type_name(combination: &[String]) -> String {
     let normalized_combo = combination
         .iter()
@@ -348,24 +398,17 @@ fn build_silent_object_type_name(combination: &[String]) -> String {
     format!("silent_{}", normalized_combo)
 }
 
-// Converts a string to a compact lowercase snake_case segment.
-// Non-alphanumeric characters become underscores; consecutive underscores are collapsed.
+// Converts a type name to a compact lowercase token by keeping only ASCII alphanumeric
+// characters and dropping everything else (spaces, hyphens, etc.).
+// This ensures multi-word type names like "Order Item" become "orderitem" rather than
+// "order_item", which would be indistinguishable from separate types "Order" + "Item"
+// once the per-part tokens are joined with "_" in build_silent_object_type_name.
 fn normalize_identifier_part(input: &str) -> String {
-    let normalized = input
+    let compact: String = input
         .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() {
-                ch.to_ascii_lowercase()
-            } else {
-                '_'
-            }
-        })
-        .collect::<String>();
-    let compact = normalized
-        .split('_')
-        .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>()
-        .join("_");
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .map(|ch| ch.to_ascii_lowercase())
+        .collect();
     if compact.is_empty() {
         "value".to_string()
     } else {

--- a/backend/src/core/resource_miner/special.rs
+++ b/backend/src/core/resource_miner/special.rs
@@ -1,0 +1,456 @@
+// Special activity features:
+//   1. Find the smallest jointly non-diverging object type combination for a special activity.
+//   2. Create silent objects for that combination and attach them to the OCEL.
+//
+// Silent objects are synthetic OCEL objects — one per unique combination instance.
+// Their type name is derived from the combination only (not the activity), so two activities
+// sharing the same combination reuse the same silent type and objects.
+
+use crate::core::resource_miner::{
+    build_object_id_to_type, is_special_activity, validate_special_activity_and_related,
+};
+use crate::models::ocel::{OCEL, OCELObject, OCELRelationship, OCELType, OCELUtils};
+use crate::models::resource_miner::{
+    FixMultipleSpecialActivitiesResponse, FixedActivityInfo, NonDivergingCombination,
+    SpecialActivityCombinationResponse,
+};
+use crate::traits::import_export::ExportableToPath;
+use axum::http::StatusCode;
+use rustc_hash::FxHashSet;
+use std::collections::{BTreeMap, BTreeSet};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+// Object participation snapshot for one event, used during combination search.
+#[derive(Debug)]
+struct ActivityEventProfile {
+    all_objects: BTreeSet<String>,
+    objects_by_type: BTreeMap<String, BTreeSet<String>>,
+}
+
+// Tracks silent objects created during a fix pass.
+// Ensures the same instance-level signature always maps to the same silent object ID,
+// even when fixing multiple activities in one call.
+struct SilentObjectRegistry {
+    // silent_type -> (signature -> silent_object_id, next_index)
+    per_type: BTreeMap<String, (BTreeMap<Vec<(String, BTreeSet<String>)>, String>, usize)>,
+}
+
+impl SilentObjectRegistry {
+    fn new() -> Self {
+        Self {
+            per_type: BTreeMap::new(),
+        }
+    }
+
+    // Returns the existing silent object ID for this signature, or creates a new one.
+    // Takes `objects` separately so this can be called while ocel.events is borrowed.
+    fn get_or_create(
+        &mut self,
+        objects: &mut Vec<OCELObject>,
+        silent_type: &str,
+        signature: Vec<(String, BTreeSet<String>)>,
+    ) -> String {
+        let (sig_map, next_idx) = self
+            .per_type
+            .entry(silent_type.to_string())
+            .or_insert((BTreeMap::new(), 1));
+
+        if let Some(existing) = sig_map.get(&signature) {
+            return existing.clone();
+        }
+
+        let generated = format!("{}_{}", silent_type, *next_idx);
+        *next_idx += 1;
+        sig_map.insert(signature, generated.clone());
+        objects.push(OCELObject {
+            id: generated.clone(),
+            object_type: silent_type.to_string(),
+            attributes: Vec::new(),
+            relationships: Vec::new(),
+        });
+        generated
+    }
+}
+
+// Finds the smallest jointly non-diverging combination for the given special activity.
+// Returns at most one combination (smallest size first).
+// Errors: 404 if activity has no related types, 400 if not a special activity.
+pub fn build_non_diverging_combinations_response(
+    ocel: &OCEL,
+    activity: &str,
+) -> Result<SpecialActivityCombinationResponse, (StatusCode, String)> {
+    let ((_divergence, _related), related_object_types) =
+        validate_special_activity_and_related(ocel, activity)?;
+
+    // Exclude silent types so the search only considers original object types.
+    let mut related_types_sorted: Vec<String> = related_object_types
+        .into_iter()
+        .filter(|t| !t.starts_with("silent_"))
+        .collect();
+    related_types_sorted.sort();
+
+    if related_types_sorted.len() < 2 {
+        return Ok(SpecialActivityCombinationResponse {
+            activity: activity.to_string(),
+            combinations: Vec::new(),
+        });
+    }
+
+    let object_id_to_type = build_object_id_to_type(ocel);
+    let activity_profiles = build_activity_event_profiles(ocel, activity, &object_id_to_type);
+
+    let mut selected_combination: Option<NonDivergingCombination> = None;
+    for size in 2..=related_types_sorted.len() {
+        let type_combinations = generate_type_combinations_of_size(&related_types_sorted, size);
+        for combination in type_combinations {
+            if evaluate_joint_non_divergence(&activity_profiles, &combination) {
+                selected_combination = Some(NonDivergingCombination {
+                    object_types: combination,
+                });
+                break;
+            }
+        }
+        if selected_combination.is_some() {
+            break;
+        }
+    }
+
+    Ok(SpecialActivityCombinationResponse {
+        activity: activity.to_string(),
+        combinations: selected_combination.into_iter().collect(),
+    })
+}
+
+// Fixes multiple special activities in one pass and exports a single new OCEL file.
+// Activities are processed in order; after each fix the OCEL state changes, so patterns
+// are recomputed per iteration — a previously special activity may no longer be special.
+// A shared registry prevents duplicate silent objects across activities.
+pub async fn fix_multiple_special_activities(
+    ocel: &mut OCEL,
+    source_file_id: &str,
+    activities: &[String],
+) -> Result<FixMultipleSpecialActivitiesResponse, (StatusCode, String)> {
+    let mut fixed: Vec<FixedActivityInfo> = Vec::new();
+    let mut skipped_not_special: Vec<String> = Vec::new();
+    let mut no_combination_found: Vec<String> = Vec::new();
+    let mut registry = SilentObjectRegistry::new();
+
+    for activity in activities {
+        // Recompute each iteration: fixing a previous activity modifies the OCEL,
+        // which can change divergence patterns for subsequent activities.
+        let (divergence, _convergence, related, _deficiency) =
+            catch_unwind(AssertUnwindSafe(|| ocel.get_interaction_patterns())).map_err(|_| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to compute interaction patterns".to_string(),
+                )
+            })?;
+
+        let related_types_set: FxHashSet<String> =
+            related.get(activity.as_str()).cloned().unwrap_or_default();
+
+        if related_types_set.is_empty() || !is_special_activity(&divergence, &related, activity) {
+            skipped_not_special.push(activity.clone());
+            continue;
+        }
+
+        // Exclude silent types added by previous fixes — we only want original object types
+        // as combination candidates, not synthetic ones we created ourselves.
+        let mut related_types_sorted: Vec<String> = related_types_set
+            .into_iter()
+            .filter(|t| !t.starts_with("silent_"))
+            .collect();
+        related_types_sorted.sort();
+
+        if related_types_sorted.len() < 2 {
+            no_combination_found.push(activity.clone());
+            continue;
+        }
+
+        // Rebuild each iteration: previous fixes add new silent objects to ocel.objects,
+        // so the map must be refreshed to include them.
+        let object_id_to_type = build_object_id_to_type(ocel);
+        let activity_profiles =
+            build_activity_event_profiles(ocel, activity, &object_id_to_type);
+
+        let mut selected: Option<Vec<String>> = None;
+        for size in 2..=related_types_sorted.len() {
+            for combo in generate_type_combinations_of_size(&related_types_sorted, size) {
+                if evaluate_joint_non_divergence(&activity_profiles, &combo) {
+                    selected = Some(combo);
+                    break;
+                }
+            }
+            if selected.is_some() {
+                break;
+            }
+        }
+
+        let combination = match selected {
+            Some(c) => c,
+            None => {
+                no_combination_found.push(activity.clone());
+                continue;
+            }
+        };
+
+        let silent_object_type = build_silent_object_type_name(&combination);
+        create_silent_object_type_if_missing(ocel, &silent_object_type);
+        attach_silent_objects(
+            ocel,
+            &combination,
+            &silent_object_type,
+            &object_id_to_type,
+            &mut registry,
+        );
+
+        fixed.push(FixedActivityInfo {
+            activity: activity.clone(),
+            combination,
+            silent_object_type,
+        });
+    }
+
+    let new_file_id = ocel.export_to_path().await?;
+    Ok(FixMultipleSpecialActivitiesResponse {
+        source_file_id: source_file_id.to_string(),
+        new_file_id,
+        fixed,
+        skipped_not_special,
+        no_combination_found,
+    })
+}
+
+// Builds an event profile for each event of the given activity type.
+// Groups each event's linked objects by their type.
+fn build_activity_event_profiles(
+    ocel: &OCEL,
+    activity: &str,
+    object_id_to_type: &BTreeMap<String, String>,
+) -> Vec<ActivityEventProfile> {
+    ocel.events
+        .iter()
+        .filter(|event| event.event_type == activity)
+        .map(|event| {
+            let mut all_objects = BTreeSet::new();
+            let mut objects_by_type: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+
+            for relation in &event.relationships {
+                all_objects.insert(relation.object_id.clone());
+                if let Some(object_type) = object_id_to_type.get(&relation.object_id) {
+                    objects_by_type
+                        .entry(object_type.clone())
+                        .or_default()
+                        .insert(relation.object_id.clone());
+                }
+            }
+
+            ActivityEventProfile {
+                all_objects,
+                objects_by_type,
+            }
+        })
+        .collect()
+}
+
+// Recursive backtracking helper that generates all `target_size`-element subsets of `types`.
+fn build_combinations_recursive(
+    types: &[String],
+    target_size: usize,
+    start_index: usize,
+    current: &mut Vec<String>,
+    all_combinations: &mut Vec<Vec<String>>,
+) {
+    if current.len() == target_size {
+        all_combinations.push(current.clone());
+        return;
+    }
+
+    for idx in start_index..types.len() {
+        current.push(types[idx].clone());
+        build_combinations_recursive(types, target_size, idx + 1, current, all_combinations);
+        current.pop();
+    }
+}
+
+// Returns true when the combination is jointly non-diverging across all profiled events.
+// Groups events by their joint signature (which concrete objects cover the combination types).
+// If any signature maps to more than one distinct context, the combination is diverging.
+fn evaluate_joint_non_divergence(
+    activity_profiles: &[ActivityEventProfile],
+    combination: &[String],
+) -> bool {
+    let mut groups: BTreeMap<Vec<(String, BTreeSet<String>)>, FxHashSet<BTreeSet<String>>> =
+        BTreeMap::new();
+
+    for profile in activity_profiles {
+        let mut joint_signature = Vec::with_capacity(combination.len());
+        let mut joint_object_ids = BTreeSet::new();
+        let mut is_complete = true;
+
+        for object_type in combination {
+            match profile.objects_by_type.get(object_type) {
+                Some(object_ids) if !object_ids.is_empty() => {
+                    joint_signature.push((object_type.clone(), object_ids.clone()));
+                    joint_object_ids.extend(object_ids.iter().cloned());
+                }
+                _ => {
+                    is_complete = false;
+                    break;
+                }
+            }
+        }
+
+        if !is_complete {
+            continue;
+        }
+
+        let context_without_joint: BTreeSet<String> = profile
+            .all_objects
+            .difference(&joint_object_ids)
+            .cloned()
+            .collect();
+        groups
+            .entry(joint_signature)
+            .or_default()
+            .insert(context_without_joint);
+    }
+
+    // No matching events — cannot confirm non-divergence.
+    if groups.is_empty() {
+        return false;
+    }
+
+    let is_divergent = groups.values().any(|contexts| contexts.len() > 1);
+    !is_divergent
+}
+
+// Returns all subsets of `types` with exactly `size` elements.
+fn generate_type_combinations_of_size(types: &[String], size: usize) -> Vec<Vec<String>> {
+    let mut combinations = Vec::new();
+    if types.len() < 2 || size < 2 || size > types.len() {
+        return combinations;
+    }
+
+    let mut current = Vec::with_capacity(size);
+    build_combinations_recursive(types, size, 0, &mut current, &mut combinations);
+    combinations
+}
+
+// Builds a snake_case silent type name from the combination's type names only (no activity).
+// Example: ["employees", "products"] -> "silent_employees_products"
+fn build_silent_object_type_name(combination: &[String]) -> String {
+    let normalized_combo = combination
+        .iter()
+        .map(|part| normalize_identifier_part(part))
+        .collect::<Vec<_>>()
+        .join("_");
+    format!("silent_{}", normalized_combo)
+}
+
+// Converts a string to a compact lowercase snake_case segment.
+// Non-alphanumeric characters become underscores; consecutive underscores are collapsed.
+fn normalize_identifier_part(input: &str) -> String {
+    let normalized = input
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let compact = normalized
+        .split('_')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("_");
+    if compact.is_empty() {
+        "value".to_string()
+    } else {
+        compact
+    }
+}
+
+// Registers the silent object type in the OCEL schema if not already present.
+fn create_silent_object_type_if_missing(ocel: &mut OCEL, silent_object_type: &str) {
+    if ocel
+        .object_types
+        .iter()
+        .any(|ot| ot.name == silent_object_type)
+    {
+        return;
+    }
+    ocel.object_types.push(OCELType {
+        name: silent_object_type.to_string(),
+        attributes: Vec::new(),
+    });
+}
+
+// Computes the combination signature for one event.
+// Returns None if any type in the combination is missing from the event.
+fn compute_event_signature(
+    event_objects_by_type: &BTreeMap<String, BTreeSet<String>>,
+    combination: &[String],
+) -> Option<Vec<(String, BTreeSet<String>)>> {
+    let mut signature = Vec::with_capacity(combination.len());
+    for object_type in combination {
+        match event_objects_by_type.get(object_type) {
+            Some(ids) if !ids.is_empty() => {
+                signature.push((object_type.clone(), ids.clone()));
+            }
+            _ => return None,
+        }
+    }
+    Some(signature)
+}
+
+// Creates silent objects for each unique combination signature and attaches them to all
+// matching events in the log. 
+fn attach_silent_objects(
+    ocel: &mut OCEL,
+    combination: &[String],
+    silent_object_type: &str,
+    object_id_to_type: &BTreeMap<String, String>,
+    registry: &mut SilentObjectRegistry,
+) {
+    // Read signatures from ocel.events
+    let event_signatures: Vec<Option<Vec<(String, BTreeSet<String>)>>> = ocel
+        .events
+        .iter()
+        .map(|event| {
+            let mut objects_by_type: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+            for relation in &event.relationships {
+                if let Some(object_type) = object_id_to_type.get(&relation.object_id) {
+                    objects_by_type
+                        .entry(object_type.clone())
+                        .or_default()
+                        .insert(relation.object_id.clone());
+                }
+            }
+            compute_event_signature(&objects_by_type, combination)
+        })
+        .collect();
+
+    // Create/resolve silent IDs in ocel.objects via registry
+    let event_silent_ids: Vec<Option<String>> = event_signatures
+        .into_iter()
+        .map(|sig_opt| {
+            sig_opt
+                .map(|sig| registry.get_or_create(&mut ocel.objects, silent_object_type, sig))
+        })
+        .collect();
+
+    // Attach silent IDs to ocel.events
+    for (event, silent_id_opt) in ocel.events.iter_mut().zip(event_silent_ids) {
+        if let Some(silent_id) = silent_id_opt {
+            if !event.relationships.iter().any(|rel| rel.object_id == silent_id) {
+                event.relationships.push(OCELRelationship {
+                    object_id: silent_id,
+                    qualifier: "silent_object".to_string(),
+                });
+            }
+        }
+    }
+}

--- a/backend/src/handlers/resource_miner.rs
+++ b/backend/src/handlers/resource_miner.rs
@@ -47,7 +47,8 @@ pub async fn get_special_activity_non_diverging_combinations(
 // Fixes multiple special activities in a single pass, exporting one new OCEL file.
 // Accepts a JSON body: { "activities": ["pick item", "reorder item"] }
 // Activities are processed in order. If fixing one makes another no longer special,
-// the latter is skipped and reported in `skipped_not_special`.
+// the latter is reported in `resolved_by_cascade`. Activities that were never
+// special in the original OCEL are reported in `skipped_not_special`.
 pub async fn post_fix_multiple_special_activities(
     Path(file_id): Path<String>,
     Json(body): Json<FixMultipleActivitiesRequest>,

--- a/backend/src/handlers/resource_miner.rs
+++ b/backend/src/handlers/resource_miner.rs
@@ -1,47 +1,11 @@
-use crate::models::ocel::{OCEL, OCELUtils};
+use crate::core::resource_miner::{
+    build_non_diverging_combinations_response, build_resource_miner_response,
+    fix_multiple_special_activities,
+};
+use crate::models::ocel::OCEL;
+use crate::models::resource_miner::FixMultipleActivitiesRequest;
 use crate::traits::import_export::ImportableFromPath;
 use axum::{Json, extract::Path, http::StatusCode, response::IntoResponse};
-use rustc_hash::FxHashSet;
-use serde::Serialize;
-use std::collections::{BTreeMap, BTreeSet};
-use std::panic::{AssertUnwindSafe, catch_unwind};
-
-#[derive(Debug, Serialize)]
-pub struct ObjectNotResourceArc {
-    pub source_type: String,
-    pub target_type: String,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ResourceMinerResponse {
-    pub object_type_not_resource: Vec<String>,
-    pub object_resource: Vec<String>,
-    pub event_types_without_object_resource: Vec<String>,
-    pub object_not_resource_arcs: Vec<ObjectNotResourceArc>,
-    pub special_activity: Vec<String>,
-}
-
-// Structure for the found non-diverging object type combinations
-#[derive(Debug, Serialize)]
-pub struct NonDivergingCombination {
-    pub object_types: Vec<String>,
-}
-
-// Response for a special activity: contains the activity name and the non-diverging object type combinations found for it
-#[derive(Debug, Serialize)]
-pub struct SpecialActivityCombinationResponse {
-    pub activity: String,
-    pub combinations: Vec<NonDivergingCombination>,
-}
-
-// Represents a single event of a specific activity:
-// - all_objects: all object IDs involved in the event
-// - objects_by_type: grouping of linked object IDs by their object type
-#[derive(Debug)]
-struct ActivityEventProfile {
-    all_objects: BTreeSet<String>,
-    objects_by_type: BTreeMap<String, BTreeSet<String>>,
-}
 
 pub async fn get_resource_miner(
     Path(file_id): Path<String>,
@@ -54,120 +18,10 @@ pub async fn get_resource_miner(
     }
 
     let ocel = OCEL::import_from_path(&file_id).await?;
-
-    let (divergence, _convergence, related, _deficiency) =
-        catch_unwind(AssertUnwindSafe(|| ocel.get_interaction_patterns())).map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to compute interaction patterns".to_string(),
-            )
-        })?;
-
-    let all_activities: Vec<String> = ocel.event_types.iter().map(|ev| ev.name.clone()).collect();
-    let all_object_types: Vec<String> =
-        ocel.object_types.iter().map(|ot| ot.name.clone()).collect();
-
-    // An object type is resource if is is divergent in every activity is is related to.
-    let mut object_resource: FxHashSet<String> = FxHashSet::default();
-    for object_type in &all_object_types {
-        let related_activities: Vec<&String> = related
-            .iter()
-            .filter_map(|(activity, related_object_types)| {
-                if related_object_types.contains(object_type) {
-                    Some(activity)
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        if related_activities.is_empty() {
-            continue;
-        }
-
-        let is_resource = related_activities.iter().all(|activity| {
-            divergence
-                .get(*activity)
-                .map(|div| div.contains(object_type))
-                .unwrap_or(false)
-        });
-
-        if is_resource {
-            object_resource.insert(object_type.clone());
-        }
-    }
-
-    // An object type is non-resource if it is not divergent in at least one related activity.
-    let mut object_type_not_resource: FxHashSet<String> = FxHashSet::default();
-    let mut object_not_resource_arcs: Vec<ObjectNotResourceArc> = Vec::new();
-
-    for activity in &all_activities {
-        let related_object_types = related.get(activity).cloned().unwrap_or_default();
-        for object_type in related_object_types {
-            let is_divergent = divergence
-                .get(activity)
-                .map(|div| div.contains(&object_type))
-                .unwrap_or(false);
-
-            if !is_divergent {
-                object_type_not_resource.insert(object_type.clone());
-                object_not_resource_arcs.push(ObjectNotResourceArc {
-                    source_type: object_type,
-                    target_type: activity.clone(),
-                });
-            }
-        }
-    }
-
-    let mut special_activity: Vec<String> = all_activities
-        .iter()
-        .filter(|activity| is_special_activity(&divergence, &related, activity))
-        .cloned()
-        .collect();
-
-    let mut event_types_without_object_resource: Vec<String> = all_activities
-        .iter()
-        .filter(|activity| {
-            if let Some(related_object_types) = related.get(*activity) {
-                !related_object_types.is_empty()
-                    && related_object_types
-                        .iter()
-                        .all(|object_type| !object_resource.contains(object_type))
-            } else {
-                false
-            }
-        })
-        .cloned()
-        .collect();
-
-    // Converting sets to arrays for JSON response
-    let mut object_resource: Vec<String> = object_resource.into_iter().collect();
-    let mut object_type_not_resource: Vec<String> = object_type_not_resource.into_iter().collect();
-
-    // Sorting arrays for deterministic JSON response
-    object_resource.sort();
-    object_type_not_resource.sort();
-    special_activity.sort();
-    event_types_without_object_resource.sort();
-    object_not_resource_arcs.sort_by(|left, right| {
-        left.source_type
-            .cmp(&right.source_type)
-            .then(left.target_type.cmp(&right.target_type))
-    });
-
-    // Creating response object
-    let response = ResourceMinerResponse {
-        object_type_not_resource,
-        object_resource,
-        event_types_without_object_resource,
-        object_not_resource_arcs,
-        special_activity,
-    };
-
+    let response = build_resource_miner_response(&ocel)?;
     Ok(Json(response))
 }
 
-// Handler for getting the non-diverging object type combinations for a special activity
 pub async fn get_special_activity_non_diverging_combinations(
     Path((file_id, activity)): Path<(String, String)>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
@@ -186,214 +40,34 @@ pub async fn get_special_activity_non_diverging_combinations(
     }
 
     let ocel = OCEL::import_from_path(&file_id).await?;
-    let (divergence, _convergence, related, _deficiency) =
-        catch_unwind(AssertUnwindSafe(|| ocel.get_interaction_patterns())).map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to compute interaction patterns".to_string(),
-            )
-        })?;
-
-    // Getting the set for related object types for the activity
-    let related_object_types = related.get(&activity).cloned().unwrap_or_default();
-    if related_object_types.is_empty() {
-        return Err((
-            StatusCode::NOT_FOUND,
-            format!("Activity '{}' has no related object types", activity),
-        ));
-    }
-
-    // Checking if the activity is a special activity (all related object types are divergent)
-    let is_special = is_special_activity(&divergence, &related, &activity);
-
-    // If the activity is not a special activity, return an error
-    if !is_special {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!("Activity '{}' is not a special activity", activity),
-        ));
-    }
-
-    // Search from size 2 upward to all related types.
-    let max_size = related_object_types.len().max(2);
-    // Converting set of related object types to list and sorting it
-    let mut related_types_sorted: Vec<String> = related_object_types.into_iter().collect();
-    related_types_sorted.sort();
-
-    // If the number of related object types is less than 2, return an empty response
-    if related_types_sorted.len() < 2 {
-        let response = SpecialActivityCombinationResponse {
-            activity,
-            combinations: Vec::new(),
-        };
-        return Ok(Json(response));
-    }
-
-    // Building the mapping from object id to object type
-    let object_id_to_type: BTreeMap<String, String> = ocel
-        .objects
-        .iter()
-        .map(|object| (object.id.clone(), object.object_type.clone()))
-        .collect();
-
-    let activity_profiles = build_activity_event_profiles(&ocel, &activity, &object_id_to_type);
-    let mut selected_combination: Option<NonDivergingCombination> = None;
-    for size in 2..=max_size {
-        let type_combinations = generate_type_combinations_of_size(&related_types_sorted, size);
-        for combination in type_combinations {
-            if evaluate_joint_non_divergence(&activity_profiles, &combination) {
-                selected_combination = Some(NonDivergingCombination {
-                    object_types: combination,
-                });
-                break;
-            }
-        }
-        if selected_combination.is_some() {
-            break;
-        }
-    }
-
-    let response = SpecialActivityCombinationResponse {
-        activity,
-        combinations: selected_combination.into_iter().collect(),
-    };
-
+    let response = build_non_diverging_combinations_response(&ocel, &activity)?;
     Ok(Json(response))
 }
 
-// Build reusable per-event profiles for one activity.
-fn build_activity_event_profiles(
-    ocel: &OCEL,
-    activity: &str,
-    object_id_to_type: &BTreeMap<String, String>,
-) -> Vec<ActivityEventProfile> {
-    ocel.events
-        .iter()
-        .filter(|event| event.event_type == activity)
-        .map(|event| {
-            let mut all_objects = BTreeSet::new();
-            let mut objects_by_type: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
-
-            for relation in &event.relationships {
-                all_objects.insert(relation.object_id.clone());
-                if let Some(object_type) = object_id_to_type.get(&relation.object_id) {
-                    objects_by_type
-                        .entry(object_type.clone())
-                        .or_default()
-                        .insert(relation.object_id.clone());
-                }
-            }
-
-            ActivityEventProfile {
-                all_objects,
-                objects_by_type,
-            }
-        })
-        .collect()
-}
-
-fn build_combinations_recursive(
-    types: &[String],
-    target_size: usize,
-    start_index: usize,
-    current: &mut Vec<String>,
-    all_combinations: &mut Vec<Vec<String>>,
-) {
-    if current.len() == target_size {
-        all_combinations.push(current.clone());
-        return;
+// Fixes multiple special activities in a single pass, exporting one new OCEL file.
+// Accepts a JSON body: { "activities": ["pick item", "reorder item"] }
+// Activities are processed in order. If fixing one makes another no longer special,
+// the latter is skipped and reported in `skipped_not_special`.
+pub async fn post_fix_multiple_special_activities(
+    Path(file_id): Path<String>,
+    Json(body): Json<FixMultipleActivitiesRequest>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if file_id.trim().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "file_id cannot be empty".to_string(),
+        ));
     }
 
-    for idx in start_index..types.len() {
-        current.push(types[idx].clone());
-        build_combinations_recursive(types, target_size, idx + 1, current, all_combinations);
-        current.pop();
-    }
-}
-
-fn evaluate_joint_non_divergence(
-    activity_profiles: &[ActivityEventProfile],
-    combination: &[String],
-) -> bool {
-    // Group by the combination's concrete object signature and track
-    // which outside contexts (objects not in the combination) occur for each signature.
-    let mut groups: BTreeMap<Vec<(String, BTreeSet<String>)>, FxHashSet<BTreeSet<String>>> =
-        BTreeMap::new();
-
-    for profile in activity_profiles {
-        // Signature of this event for the tested combination
-        // (e.g., Worker->{W1}, Machine->{M2}).
-        let mut joint_signature = Vec::with_capacity(combination.len());
-        // All object IDs that belong to the tested combination.
-        let mut joint_object_ids = BTreeSet::new();
-        // Event is valid for this combo only if all combo types are present.
-        let mut is_complete = true;
-
-        for object_type in combination {
-            match profile.objects_by_type.get(object_type) {
-                Some(object_ids) if !object_ids.is_empty() => {
-                    joint_signature.push((object_type.clone(), object_ids.clone()));
-                    joint_object_ids.extend(object_ids.iter().cloned());
-                }
-                _ => {
-                    is_complete = false;
-                    break;
-                }
-            }
-        }
-
-        if !is_complete {
-            // Skip events that do not contain all object types in the combination.
-            continue;
-        }
-
-        // Treat the combination as one unit: compare only the context outside it.
-        let context_without_joint: BTreeSet<String> = profile
-            .all_objects
-            .difference(&joint_object_ids)
-            .cloned()
-            .collect();
-        groups
-            .entry(joint_signature)
-            .or_default()
-            .insert(context_without_joint);
+    if body.activities.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "activities list cannot be empty".to_string(),
+        ));
     }
 
-    if groups.is_empty() {
-        // No event contained all types from this combination.
-        return false;
-    }
-
-    // Divergent if one signature appears with multiple outside contexts.
-    let is_divergent = groups.values().any(|overall_sets| overall_sets.len() > 1);
-    !is_divergent
-}
-
-fn is_special_activity(
-    divergence: &rustc_hash::FxHashMap<String, FxHashSet<String>>,
-    related: &rustc_hash::FxHashMap<String, FxHashSet<String>>,
-    activity: &str,
-) -> bool {
-    if let Some(related_object_types) = related.get(activity) {
-        !related_object_types.is_empty()
-            && related_object_types.iter().all(|object_type| {
-                divergence
-                    .get(activity)
-                    .map(|div| div.contains(object_type))
-                    .unwrap_or(false)
-            })
-    } else {
-        false
-    }
-}
-
-fn generate_type_combinations_of_size(types: &[String], size: usize) -> Vec<Vec<String>> {
-    let mut combinations = Vec::new();
-    if types.len() < 2 || size < 2 || size > types.len() {
-        return combinations;
-    }
-
-    let mut current = Vec::with_capacity(size);
-    build_combinations_recursive(types, size, 0, &mut current, &mut combinations);
-    combinations
+    let mut ocel = OCEL::import_from_path(&file_id).await?;
+    let response =
+        fix_multiple_special_activities(&mut ocel, &file_id, &body.activities).await?;
+    Ok(Json(response))
 }

--- a/backend/src/handlers/resource_miner.rs
+++ b/backend/src/handlers/resource_miner.rs
@@ -3,6 +3,7 @@ use crate::traits::import_export::ImportableFromPath;
 use axum::{Json, extract::Path, http::StatusCode, response::IntoResponse};
 use rustc_hash::FxHashSet;
 use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 #[derive(Debug, Serialize)]
@@ -20,11 +21,38 @@ pub struct ResourceMinerResponse {
     pub special_activity: Vec<String>,
 }
 
+// Structure for the found non-diverging object type combinations
+#[derive(Debug, Serialize)]
+pub struct NonDivergingCombination {
+    pub object_types: Vec<String>,
+    pub considered_events: usize,
+    pub joint_signatures: usize,
+}
+
+// Response for a special activity: contains the activity name and the non-diverging object type combinations found for it
+#[derive(Debug, Serialize)]
+pub struct SpecialActivityCombinationResponse {
+    pub activity: String,
+    pub combinations: Vec<NonDivergingCombination>,
+}
+
+// Represents a single event of a specific activity:
+// - all_objects: all object IDs involved in the event
+// - objects_by_type: grouping of relevant object IDs by their object type
+#[derive(Debug)]
+struct ActivityEventProfile {
+    all_objects: BTreeSet<String>,
+    objects_by_type: BTreeMap<String, BTreeSet<String>>,
+}
+
 pub async fn get_resource_miner(
     Path(file_id): Path<String>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     if file_id.trim().is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "file_id cannot be empty".to_string()));
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "file_id cannot be empty".to_string(),
+        ));
     }
 
     let ocel = OCEL::import_from_path(&file_id).await?;
@@ -38,7 +66,8 @@ pub async fn get_resource_miner(
         })?;
 
     let all_activities: Vec<String> = ocel.event_types.iter().map(|ev| ev.name.clone()).collect();
-    let all_object_types: Vec<String> = ocel.object_types.iter().map(|ot| ot.name.clone()).collect();
+    let all_object_types: Vec<String> =
+        ocel.object_types.iter().map(|ot| ot.name.clone()).collect();
 
     // An object type is resource if is is divergent in every activity is is related to.
     let mut object_resource: FxHashSet<String> = FxHashSet::default();
@@ -92,22 +121,9 @@ pub async fn get_resource_miner(
         }
     }
 
-    // An activity is special if all its related object types are divergent for that activity
     let mut special_activity: Vec<String> = all_activities
         .iter()
-        .filter(|activity| {
-            if let Some(related_object_types) = related.get(*activity) {
-                !related_object_types.is_empty()
-                    && related_object_types.iter().all(|object_type| {
-                        divergence
-                            .get(*activity)
-                            .map(|div| div.contains(object_type))
-                            .unwrap_or(false)
-                    })
-            } else {
-                false
-            }
-        })
+        .filter(|activity| is_special_activity(&divergence, &related, activity))
         .cloned()
         .collect();
 
@@ -151,4 +167,249 @@ pub async fn get_resource_miner(
     };
 
     Ok(Json(response))
+}
+
+// Handler for getting the non-diverging object type combinations for a special activity
+pub async fn get_special_activity_non_diverging_combinations(
+    Path((file_id, activity)): Path<(String, String)>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if file_id.trim().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "file_id cannot be empty".to_string(),
+        ));
+    }
+
+    if activity.trim().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "activity cannot be empty".to_string(),
+        ));
+    }
+
+    let ocel = OCEL::import_from_path(&file_id).await?;
+    let (divergence, _convergence, related, _deficiency) =
+        catch_unwind(AssertUnwindSafe(|| ocel.get_interaction_patterns())).map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to compute interaction patterns".to_string(),
+            )
+        })?;
+
+    // Getting the set for related object types for the activity
+    let related_object_types = related.get(&activity).cloned().unwrap_or_default();
+    if related_object_types.is_empty() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("Activity '{}' has no related object types", activity),
+        ));
+    }
+
+    // Checking if the activity is a special activity (all related object types are divergent)
+    let is_special = is_special_activity(&divergence, &related, &activity);
+
+    // If the activity is not a special activity, return an error
+    if !is_special {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("Activity '{}' is not a special activity", activity),
+        ));
+    }
+
+    // Search from size 2 upward to all related types.
+    let max_size = related_object_types.len().max(2);
+    // Converting set of related object types to list and sorting it
+    let mut related_types_sorted: Vec<String> = related_object_types.into_iter().collect();
+    related_types_sorted.sort();
+
+    // If the number of related object types is less than 2, return an empty response
+    if related_types_sorted.len() < 2 {
+        let response = SpecialActivityCombinationResponse {
+            activity,
+            combinations: Vec::new(),
+        };
+        return Ok(Json(response));
+    }
+
+    // Building the mapping from object id to object type
+    let object_id_to_type: BTreeMap<String, String> = ocel
+        .objects
+        .iter()
+        .map(|object| (object.id.clone(), object.object_type.clone()))
+        .collect();
+
+    let activity_profiles =
+        build_activity_event_profiles(&ocel, &activity, &related_types_sorted, &object_id_to_type);
+    let mut selected_combination: Option<NonDivergingCombination> = None;
+    for size in 2..=max_size {
+        let type_combinations = generate_type_combinations_of_size(&related_types_sorted, size);
+        for combination in type_combinations {
+            if let Some((considered_events, joint_signatures)) =
+                evaluate_joint_non_divergence(&activity_profiles, &combination)
+            {
+                selected_combination = Some(NonDivergingCombination {
+                    object_types: combination,
+                    considered_events,
+                    joint_signatures,
+                });
+                break;
+            }
+        }
+        if selected_combination.is_some() {
+            break;
+        }
+    }
+
+    let response = SpecialActivityCombinationResponse {
+        activity,
+        combinations: selected_combination.into_iter().collect(),
+    };
+
+    Ok(Json(response))
+}
+
+// Build reusable data for each event of one activity
+fn build_activity_event_profiles(
+    ocel: &OCEL,
+    activity: &str,
+    _related_types_sorted: &[String],
+    object_id_to_type: &BTreeMap<String, String>,
+) -> Vec<ActivityEventProfile> {
+    ocel.events
+        .iter()
+        .filter(|event| event.event_type == activity)
+        .map(|event| {
+            let mut all_objects = BTreeSet::new();
+            let mut objects_by_type: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+
+            for relation in &event.relationships {
+                all_objects.insert(relation.object_id.clone());
+                if let Some(object_type) = object_id_to_type.get(&relation.object_id) {
+                    objects_by_type
+                        .entry(object_type.clone())
+                        .or_default()
+                        .insert(relation.object_id.clone());
+                }
+            }
+
+            ActivityEventProfile {
+                all_objects,
+                objects_by_type,
+            }
+        })
+        .collect()
+}
+
+fn build_combinations_recursive(
+    types: &[String],
+    target_size: usize,
+    start_index: usize,
+    current: &mut Vec<String>,
+    all_combinations: &mut Vec<Vec<String>>,
+) {
+    if current.len() == target_size {
+        all_combinations.push(current.clone());
+        return;
+    }
+
+    for idx in start_index..types.len() {
+        current.push(types[idx].clone());
+        build_combinations_recursive(types, target_size, idx + 1, current, all_combinations);
+        current.pop();
+    }
+}
+
+fn evaluate_joint_non_divergence(
+    activity_profiles: &[ActivityEventProfile],
+    combination: &[String],
+) -> Option<(usize, usize)> {
+    // Group by the combination's concrete object signature.
+    // For each signature we collect the set of "outside" contexts.
+    let mut groups: BTreeMap<Vec<(String, BTreeSet<String>)>, FxHashSet<BTreeSet<String>>> =
+        BTreeMap::new();
+    let mut considered_events = 0usize;
+
+    for profile in activity_profiles {
+        // Signature of this event for the tested combination
+        // (e.g., Worker->{W1}, Machine->{M2}).
+        let mut joint_signature = Vec::with_capacity(combination.len());
+        // All object IDs that belong to the tested combination.
+        let mut joint_object_ids = BTreeSet::new();
+        // Event is valid for this combo only if all combo types are present.
+        let mut is_complete = true;
+
+        for object_type in combination {
+            match profile.objects_by_type.get(object_type) {
+                Some(object_ids) if !object_ids.is_empty() => {
+                    joint_signature.push((object_type.clone(), object_ids.clone()));
+                    joint_object_ids.extend(object_ids.iter().cloned());
+                }
+                _ => {
+                    is_complete = false;
+                    break;
+                }
+            }
+        }
+
+        if !is_complete {
+            // Skip events that do not contain all object types in the combination.
+            continue;
+        }
+
+        considered_events += 1;
+        // Treat the combination as one unit: compare only the context outside it.
+        let context_without_joint: BTreeSet<String> = profile
+            .all_objects
+            .difference(&joint_object_ids)
+            .cloned()
+            .collect();
+        groups
+            .entry(joint_signature)
+            .or_default()
+            .insert(context_without_joint);
+    }
+
+    if groups.is_empty() {
+        // No event contained all types from this combination.
+        return None;
+    }
+
+    // Divergent if same combination signature appears with different outside contexts.
+    let is_divergent = groups.values().any(|overall_sets| overall_sets.len() > 1);
+    if is_divergent {
+        return None;
+    }
+
+    // Non-divergent combination:
+    // (number of usable events, number of distinct joint signatures).
+    Some((considered_events, groups.len()))
+}
+
+fn is_special_activity(
+    divergence: &rustc_hash::FxHashMap<String, FxHashSet<String>>,
+    related: &rustc_hash::FxHashMap<String, FxHashSet<String>>,
+    activity: &str,
+) -> bool {
+    if let Some(related_object_types) = related.get(activity) {
+        !related_object_types.is_empty()
+            && related_object_types.iter().all(|object_type| {
+                divergence
+                    .get(activity)
+                    .map(|div| div.contains(object_type))
+                    .unwrap_or(false)
+            })
+    } else {
+        false
+    }
+}
+
+fn generate_type_combinations_of_size(types: &[String], size: usize) -> Vec<Vec<String>> {
+    let mut combinations = Vec::new();
+    if types.len() < 2 || size < 2 || size > types.len() {
+        return combinations;
+    }
+
+    let mut current = Vec::with_capacity(size);
+    build_combinations_recursive(types, size, 0, &mut current, &mut combinations);
+    combinations
 }

--- a/backend/src/handlers/resource_miner.rs
+++ b/backend/src/handlers/resource_miner.rs
@@ -25,8 +25,6 @@ pub struct ResourceMinerResponse {
 #[derive(Debug, Serialize)]
 pub struct NonDivergingCombination {
     pub object_types: Vec<String>,
-    pub considered_events: usize,
-    pub joint_signatures: usize,
 }
 
 // Response for a special activity: contains the activity name and the non-diverging object type combinations found for it
@@ -38,7 +36,7 @@ pub struct SpecialActivityCombinationResponse {
 
 // Represents a single event of a specific activity:
 // - all_objects: all object IDs involved in the event
-// - objects_by_type: grouping of relevant object IDs by their object type
+// - objects_by_type: grouping of linked object IDs by their object type
 #[derive(Debug)]
 struct ActivityEventProfile {
     all_objects: BTreeSet<String>,
@@ -238,19 +236,14 @@ pub async fn get_special_activity_non_diverging_combinations(
         .map(|object| (object.id.clone(), object.object_type.clone()))
         .collect();
 
-    let activity_profiles =
-        build_activity_event_profiles(&ocel, &activity, &related_types_sorted, &object_id_to_type);
+    let activity_profiles = build_activity_event_profiles(&ocel, &activity, &object_id_to_type);
     let mut selected_combination: Option<NonDivergingCombination> = None;
     for size in 2..=max_size {
         let type_combinations = generate_type_combinations_of_size(&related_types_sorted, size);
         for combination in type_combinations {
-            if let Some((considered_events, joint_signatures)) =
-                evaluate_joint_non_divergence(&activity_profiles, &combination)
-            {
+            if evaluate_joint_non_divergence(&activity_profiles, &combination) {
                 selected_combination = Some(NonDivergingCombination {
                     object_types: combination,
-                    considered_events,
-                    joint_signatures,
                 });
                 break;
             }
@@ -268,11 +261,10 @@ pub async fn get_special_activity_non_diverging_combinations(
     Ok(Json(response))
 }
 
-// Build reusable data for each event of one activity
+// Build reusable per-event profiles for one activity.
 fn build_activity_event_profiles(
     ocel: &OCEL,
     activity: &str,
-    _related_types_sorted: &[String],
     object_id_to_type: &BTreeMap<String, String>,
 ) -> Vec<ActivityEventProfile> {
     ocel.events
@@ -322,12 +314,11 @@ fn build_combinations_recursive(
 fn evaluate_joint_non_divergence(
     activity_profiles: &[ActivityEventProfile],
     combination: &[String],
-) -> Option<(usize, usize)> {
-    // Group by the combination's concrete object signature.
-    // For each signature we collect the set of "outside" contexts.
+) -> bool {
+    // Group by the combination's concrete object signature and track
+    // which outside contexts (objects not in the combination) occur for each signature.
     let mut groups: BTreeMap<Vec<(String, BTreeSet<String>)>, FxHashSet<BTreeSet<String>>> =
         BTreeMap::new();
-    let mut considered_events = 0usize;
 
     for profile in activity_profiles {
         // Signature of this event for the tested combination
@@ -356,7 +347,6 @@ fn evaluate_joint_non_divergence(
             continue;
         }
 
-        considered_events += 1;
         // Treat the combination as one unit: compare only the context outside it.
         let context_without_joint: BTreeSet<String> = profile
             .all_objects
@@ -371,18 +361,12 @@ fn evaluate_joint_non_divergence(
 
     if groups.is_empty() {
         // No event contained all types from this combination.
-        return None;
+        return false;
     }
 
-    // Divergent if same combination signature appears with different outside contexts.
+    // Divergent if one signature appears with multiple outside contexts.
     let is_divergent = groups.values().any(|overall_sets| overall_sets.len() > 1);
-    if is_divergent {
-        return None;
-    }
-
-    // Non-divergent combination:
-    // (number of usable events, number of distinct joint signatures).
-    Some((considered_events, groups.len()))
+    !is_divergent
 }
 
 fn is_special_activity(

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -7,3 +7,4 @@ pub mod ocel_collection;
 pub mod ocel_sid_df2_miner;
 pub mod ocpn;
 pub mod ocpt;
+pub mod resource_miner;

--- a/backend/src/models/resource_miner.rs
+++ b/backend/src/models/resource_miner.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize)]
+pub struct ObjectNotResourceArc {
+    pub source_type: String,
+    pub target_type: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResourceMinerResponse {
+    pub object_type_not_resource: Vec<String>,
+    pub object_resource: Vec<String>,
+    pub event_types_without_object_resource: Vec<String>,
+    pub object_not_resource_arcs: Vec<ObjectNotResourceArc>,
+    pub special_activity: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NonDivergingCombination {
+    pub object_types: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SpecialActivityCombinationResponse {
+    pub activity: String,
+    pub combinations: Vec<NonDivergingCombination>,
+}
+
+// Info about a single successfully fixed activity, included in the multi-fix response.
+#[derive(Debug, Serialize)]
+pub struct FixedActivityInfo {
+    pub activity: String,
+    pub combination: Vec<String>,
+    pub silent_object_type: String,
+}
+
+// Request body for the multi-fix endpoint.
+#[derive(Debug, Deserialize)]
+pub struct FixMultipleActivitiesRequest {
+    pub activities: Vec<String>,
+}
+
+// Response for fixing multiple special activities in one pass.
+// fixed              : activities that were successfully fixed
+// skipped_not_special: activities that were no longer special by the time they were processed
+//                      (can happen because fixing an earlier activity may change divergence patterns)
+// no_combination_found: activities that are still special but have no jointly non-diverging combination
+#[derive(Debug, Serialize)]
+pub struct FixMultipleSpecialActivitiesResponse {
+    pub source_file_id: String,
+    pub new_file_id: String,
+    pub fixed: Vec<FixedActivityInfo>,
+    pub skipped_not_special: Vec<String>,
+    pub no_combination_found: Vec<String>,
+}

--- a/backend/src/models/resource_miner.rs
+++ b/backend/src/models/resource_miner.rs
@@ -13,7 +13,7 @@ pub struct ResourceMinerResponse {
     pub non_special_event_types: Vec<String>,
     pub event_types_without_object_resource: Vec<String>,
     pub object_not_resource_arcs: Vec<ObjectNotResourceArc>,
-    pub special_activity: Vec<String>,
+    pub special_activities: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -42,15 +42,18 @@ pub struct FixMultipleActivitiesRequest {
 }
 
 // Response for fixing multiple special activities in one pass.
-// fixed              : activities that were successfully fixed
-// skipped_not_special: activities that were no longer special by the time they were processed
-//                      (can happen because fixing an earlier activity may change divergence patterns)
-// no_combination_found: activities that are still special but have no jointly non-diverging combination
+// fixed                : activities that were successfully fixed
+// skipped_not_special  : requested activities that were not special in the original OCEL at all
+// resolved_by_cascade  : activities that were originally special but became non-special as a
+//                        side-effect of fixing other activities — whether or not they appeared
+//                        in the request list
+// no_combination_found : activities that are still special but have no jointly non-diverging combination
 #[derive(Debug, Serialize)]
 pub struct FixMultipleSpecialActivitiesResponse {
     pub source_file_id: String,
     pub new_file_id: String,
     pub fixed: Vec<FixedActivityInfo>,
     pub skipped_not_special: Vec<String>,
+    pub resolved_by_cascade: Vec<String>,
     pub no_combination_found: Vec<String>,
 }

--- a/backend/src/routes/v1/resource_miner.rs
+++ b/backend/src/routes/v1/resource_miner.rs
@@ -1,7 +1,11 @@
 use crate::handlers::resource_miner::{
     get_resource_miner, get_special_activity_non_diverging_combinations,
+    post_fix_multiple_special_activities,
 };
-use axum::{Router, routing::get};
+use axum::{
+    Router,
+    routing::{get, post},
+};
 
 pub fn router() -> Router {
     Router::new()
@@ -9,5 +13,9 @@ pub fn router() -> Router {
         .route(
             "/{file_id}/special/{activity}/non_diverging_combinations",
             get(get_special_activity_non_diverging_combinations),
+        )
+        .route(
+            "/{file_id}/fix_multiple_special_activities",
+            post(post_fix_multiple_special_activities),
         )
 }

--- a/backend/src/routes/v1/resource_miner.rs
+++ b/backend/src/routes/v1/resource_miner.rs
@@ -1,6 +1,13 @@
-use crate::handlers::resource_miner::get_resource_miner;
+use crate::handlers::resource_miner::{
+    get_resource_miner, get_special_activity_non_diverging_combinations,
+};
 use axum::{Router, routing::get};
 
 pub fn router() -> Router {
-    Router::new().route("/{file_id}", get(get_resource_miner))
+    Router::new()
+        .route("/{file_id}", get(get_resource_miner))
+        .route(
+            "/{file_id}/special/{activity}/non_diverging_combinations",
+            get(get_special_activity_non_diverging_combinations),
+        )
 }


### PR DESCRIPTION
**Fix Multiple Special Activities**
Method: POST
Path: /v1/resource_miner/{file_id}/fix_multiple_special_activities

**Purpose**
Processes multiple special activities in sequence, applies the non-diverging combination fix where possible, and exports a single transformed OCEL file.

**Request Body**
{
  "activities": ["item out of stock", "reorder item"]
}

**Response Body**
{
  "source_file_id": "order-management-no-items",
  "new_file_id": "80e5ad90-b1f3-4b57-8c34-560246beef9c",
  "fixed": [
    {
      "activity": "item out of stock",
      "combination": ["employees", "products"],
      "silent_object_type": "silent_employees_products"
    }
  ],
  "skipped_not_special": [],
  "resolved_by_cascade": ["pick item", "reorder item"],
  "no_combination_found": []
}

**Response Field Definitions**

- source_file_id: Identifier of the input OCEL file used as source.
- new_file_id: Identifier of the exported OCEL file produced after all processing.
- fixed: List of activities successfully fixed.
- activity: Activity name that was fixed.
- combination: Selected smallest jointly non-diverging object-type combination.
- silent_object_type: Synthetic object type created/used for that combination.
- skipped_not_special: Requested activities that were not special in the original OCEL and were therefore skipped.
- resolved_by_cascade: Activities that were special in the original OCEL but became non-special as a side-effect of fixing other activities. Includes both activities that appeared in the request and those that did not.
- no_combination_found: Activities that remained special after all fixes but for which no valid jointly non-diverging combination could be found.

**Processing Semantics**
Activities are evaluated in request order. OCEL state is updated incrementally after each successful fix. Interaction patterns are recomputed before processing each next activity. A later activity in the request may be skipped if an earlier fix resolves its specialness, it will then appear in resolved_by_cascade. After all activities are processed, a final pattern check is performed across all originally-special activities (not just those in the request) to capture any additional cascade resolutions. The source OCEL file remains unchanged; output is written as a new file referenced by new_file_id.