### PR TITLE
added optional cluster_ids selection

### DIFF
--- a/backend/src/handlers/clustering.rs
+++ b/backend/src/handlers/clustering.rs
@@ -22,7 +22,7 @@ use axum::{
 use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs::OpenOptions;
 use std::io::{BufWriter, Write};
 use std::time::Instant;
@@ -123,6 +123,7 @@ struct AgglomerativeClusteringArtifact {
 #[derive(Deserialize)]
 pub struct MaterializeClusteredCasesRequest {
     pub case_assignments: Vec<(String, usize)>,
+    pub cluster_ids: Option<Vec<usize>>,
 }
 
 #[derive(Serialize)]
@@ -401,6 +402,68 @@ fn validate_materialize_assignments(
     Ok(normalized_assignments)
 }
 
+fn validate_requested_cluster_ids(
+    requested_cluster_ids: Option<&[usize]>,
+    grouped_case_indices: &BTreeMap<usize, Vec<usize>>,
+) -> Result<Option<BTreeSet<usize>>, String> {
+    let Some(requested_cluster_ids) = requested_cluster_ids else {
+        return Ok(None);
+    };
+
+    if requested_cluster_ids.is_empty() {
+        return Err(
+            "cluster_ids cannot be empty; omit it to materialize all clusters.".to_string(),
+        );
+    }
+
+    let available_cluster_ids: BTreeSet<usize> = grouped_case_indices.keys().copied().collect();
+    let mut selected_cluster_ids = BTreeSet::new();
+    let mut duplicates = Vec::new();
+    let mut unknown = Vec::new();
+
+    for &cluster_id in requested_cluster_ids {
+        if !selected_cluster_ids.insert(cluster_id) {
+            duplicates.push(cluster_id);
+        }
+        if !available_cluster_ids.contains(&cluster_id) {
+            unknown.push(cluster_id);
+        }
+    }
+
+    if !duplicates.is_empty() {
+        duplicates.sort_unstable();
+        duplicates.dedup();
+        return Err(format!(
+            "Duplicate cluster_ids are not allowed: {}",
+            duplicates
+                .iter()
+                .map(usize::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    if !unknown.is_empty() {
+        unknown.sort_unstable();
+        unknown.dedup();
+        return Err(format!(
+            "cluster_ids contains unknown cluster id(s): {}. Available cluster id(s): {}",
+            unknown
+                .iter()
+                .map(usize::to_string)
+                .collect::<Vec<_>>()
+                .join(", "),
+            available_cluster_ids
+                .iter()
+                .map(usize::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    Ok(Some(selected_cluster_ids))
+}
+
 fn clustered_case_collection_payload(
     source_attributes: &HashMap<String, Value>,
     source_case_ocels_file_id: &str,
@@ -530,8 +593,22 @@ pub async fn materialize_clustered_case_ocels(
         }
     }
 
+    let selected_cluster_ids =
+        match validate_requested_cluster_ids(request.cluster_ids.as_deref(), &grouped_case_indices)
+        {
+            Ok(selected_cluster_ids) => selected_cluster_ids,
+            Err(message) => return (StatusCode::BAD_REQUEST, message).into_response(),
+        };
+
     let mut materialized_clusters = Vec::with_capacity(grouped_case_indices.len());
     for (cluster_id, indices) in grouped_case_indices {
+        if selected_cluster_ids
+            .as_ref()
+            .is_some_and(|selected| !selected.contains(&cluster_id))
+        {
+            continue;
+        }
+
         if indices.is_empty() {
             continue;
         }
@@ -1211,6 +1288,29 @@ mod tests {
         assert!(err.contains("Duplicate source case id"));
     }
 
+    #[test]
+    fn materialize_cluster_selection_validates_requested_ids() {
+        let grouped_case_indices = BTreeMap::from([(0, vec![1]), (2, vec![0, 2])]);
+
+        assert!(
+            validate_requested_cluster_ids(None, &grouped_case_indices)
+                .unwrap()
+                .is_none()
+        );
+
+        let selected = validate_requested_cluster_ids(Some(&[2]), &grouped_case_indices).unwrap();
+        assert_eq!(selected.unwrap(), BTreeSet::from([2]));
+
+        let err = validate_requested_cluster_ids(Some(&[]), &grouped_case_indices).unwrap_err();
+        assert!(err.contains("cluster_ids cannot be empty"));
+
+        let err = validate_requested_cluster_ids(Some(&[2, 2]), &grouped_case_indices).unwrap_err();
+        assert!(err.contains("Duplicate cluster_ids"));
+
+        let err = validate_requested_cluster_ids(Some(&[1]), &grouped_case_indices).unwrap_err();
+        assert!(err.contains("unknown cluster id"));
+    }
+
     #[tokio::test]
     async fn materialize_handler_writes_clustered_case_files() {
         fs::create_dir_all("./temp").await.unwrap();
@@ -1242,6 +1342,7 @@ mod tests {
                     ("1".to_string(), 0),
                     ("2".to_string(), 1),
                 ],
+                cluster_ids: None,
             }),
         )
         .await
@@ -1302,6 +1403,63 @@ mod tests {
         for path in created_paths {
             fs::remove_file(path).await.unwrap();
         }
+        fs::remove_file(source_path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn materialize_handler_writes_only_requested_clusters() {
+        fs::create_dir_all("./temp").await.unwrap();
+        let source_file_id = Uuid::new_v4().to_string();
+        let source_path = format!("./temp/case_ocels_{source_file_id}.json");
+        let source_payload = json!({
+            "origin_file_id_ocel": "source-1",
+            "case_notion_type": "Traditional Case Notion (case)",
+            "object_type": "case",
+            "case_notion_file_id": "cn-1",
+            "case_ocels": [
+                sample_case("o1", &["A"]),
+                sample_case("o2", &["B"]),
+                sample_case("o3", &["C"])
+            ]
+        });
+        fs::write(
+            &source_path,
+            serde_json::to_string(&source_payload).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let response = materialize_clustered_case_ocels(
+            Path(source_file_id.clone()),
+            Json(MaterializeClusteredCasesRequest {
+                case_assignments: vec![
+                    ("0".to_string(), 1),
+                    ("1".to_string(), 0),
+                    ("2".to_string(), 1),
+                ],
+                cluster_ids: Some(vec![0]),
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let payload: Value = serde_json::from_slice(&body).unwrap();
+        let clusters = payload["materialized_clusters"].as_array().unwrap();
+        assert_eq!(clusters.len(), 1);
+        assert_eq!(clusters[0]["cluster_id"].as_u64(), Some(0));
+        assert_eq!(clusters[0]["case_count"].as_u64(), Some(1));
+
+        let cluster_case_ocels_file_id = clusters[0]["case_ocels_file_id"].as_str().unwrap();
+        let path = case_ocels_collection_path(cluster_case_ocels_file_id);
+        let stored: Value =
+            serde_json::from_str(&fs::read_to_string(&path).await.unwrap()).unwrap();
+        assert_eq!(stored["cluster_id"].as_u64(), Some(0));
+        assert_eq!(stored["case_count"].as_u64(), Some(1));
+        assert_eq!(stored["case_assignments"].as_array().unwrap().len(), 1);
+
+        fs::remove_file(path).await.unwrap();
         fs::remove_file(source_path).await.unwrap();
     }
 


### PR DESCRIPTION
## Summary

- Add optional `cluster_ids` to `POST /v1/clustering/materialize/{case_ocels_file_id}` so callers can materialize selected clusters instead of always writing every cluster.
- Preserve existing behavior when `cluster_ids` is omitted: all non-empty clusters are materialized.
- Validate selected cluster IDs and reject empty, duplicate, or unknown selections with `400`.
- Add focused tests for default all-cluster behavior, selected-cluster materialization, and `cluster_ids` validation.

## API Contract

Existing request shape still works:

```json
{
  "case_assignments": [["0", 1], ["1", 0], ["2", 1]]
}
```

New optional selection shape:

```json
{
  "case_assignments": [["0", 1], ["1", 0], ["2", 1]],
  "cluster_ids": [0]
}
```

Behavior:

- `cluster_ids` omitted: materialize all non-empty clusters.
- `cluster_ids` provided: materialize only those cluster IDs.
- `cluster_ids: []`: rejected.
- Duplicate cluster IDs: rejected.
- Cluster IDs not present in `case_assignments`: rejected.
