### PR TITLE
change kpi input to case ocel file

### DIFF
--- a/backend/src/core/kpi/case_kpis.rs
+++ b/backend/src/core/kpi/case_kpis.rs
@@ -1,10 +1,7 @@
 use crate::core::kpi::attribute_stats::attr_to_f64;
 use crate::models::kpi::CombinationOperator;
-use crate::models::ocel::{OCELEvent, OCELObject};
+use crate::models::ocel::OCEL;
 use rustc_hash::{FxHashMap, FxHashSet};
-
-/// A single case: (event_ids, object_ids, e2o arches).
-pub type CaseEntry = (Vec<String>, Vec<String>, Vec<(String, String)>);
 
 pub struct CaseKpiValues {
     pub values: Vec<f64>,
@@ -34,11 +31,46 @@ fn reduce_values(values: &[f64], intra_case_agg: &str) -> Option<f64> {
     }
 }
 
+/// Maps each object id in a case OCEL to its object type.
+fn object_type_map(case: &OCEL) -> FxHashMap<&str, &str> {
+    case.objects
+        .iter()
+        .map(|o| (o.id.as_str(), o.object_type.as_str()))
+        .collect()
+}
+
+/// Per-object event timelines for objects of `object_type`, sorted by time.
+fn build_object_timelines<'a>(
+    case: &'a OCEL,
+    object_type: &str,
+) -> FxHashMap<&'a str, Vec<(chrono::DateTime<chrono::FixedOffset>, &'a str)>> {
+    let obj_types = object_type_map(case);
+    let mut timelines: FxHashMap<&str, Vec<(chrono::DateTime<chrono::FixedOffset>, &str)>> =
+        FxHashMap::default();
+
+    for event in &case.events {
+        for rel in &event.relationships {
+            let obj_id = rel.object_id.as_str();
+            match obj_types.get(obj_id) {
+                Some(&ot) if ot == object_type => {}
+                _ => continue,
+            }
+            timelines
+                .entry(obj_id)
+                .or_default()
+                .push((event.time, event.event_type.as_str()));
+        }
+    }
+
+    for timeline in timelines.values_mut() {
+        timeline.sort_by_key(|(t, _)| *t);
+    }
+    timelines
+}
+
+/// Numeric values of `attribute` within a single case OCEL
 fn collect_case_attribute_values(
-    event_ids: &[String],
-    object_ids: &[String],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-    object_lookup: &FxHashMap<String, &OCELObject>,
+    case: &OCEL,
     attribute: &str,
     filter_object_type: Option<&str>,
     filter_event_type: Option<&str>,
@@ -46,31 +78,27 @@ fn collect_case_attribute_values(
     let mut values: Vec<f64> = Vec::new();
 
     if let Some(ot) = filter_object_type {
-        for object_id in object_ids {
-            if let Some(obj) = object_lookup.get(object_id) {
-                if obj.object_type != ot {
-                    continue;
-                }
-                for attr in &obj.attributes {
-                    if attr.name == attribute {
-                        if let Some(v) = attr_to_f64(&attr.value) {
-                            values.push(v);
-                        }
+        for obj in &case.objects {
+            if obj.object_type != ot {
+                continue;
+            }
+            for attr in &obj.attributes {
+                if attr.name == attribute {
+                    if let Some(v) = attr_to_f64(&attr.value) {
+                        values.push(v);
                     }
                 }
             }
         }
     } else if let Some(et) = filter_event_type {
-        for event_id in event_ids {
-            if let Some(event) = event_lookup.get(event_id) {
-                if event.event_type != et {
-                    continue;
-                }
-                for attr in &event.attributes {
-                    if attr.name == attribute {
-                        if let Some(v) = attr_to_f64(&attr.value) {
-                            values.push(v);
-                        }
+        for event in &case.events {
+            if event.event_type != et {
+                continue;
+            }
+            for attr in &event.attributes {
+                if attr.name == attribute {
+                    if let Some(v) = attr_to_f64(&attr.value) {
+                        values.push(v);
                     }
                 }
             }
@@ -82,9 +110,7 @@ fn collect_case_attribute_values(
 
 /// One KPI value per case (requires `intra_case_agg`).
 pub fn collect_case_attribute_kpi_values(
-    cases: &[CaseEntry],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-    object_lookup: &FxHashMap<String, &OCELObject>,
+    cases: &[OCEL],
     attribute: &str,
     filter_object_type: Option<&str>,
     filter_event_type: Option<&str>,
@@ -92,8 +118,6 @@ pub fn collect_case_attribute_kpi_values(
 ) -> CaseKpiValues {
     case_kpi_values_from_per_case(collect_per_case_attribute_kpi_values(
         cases,
-        event_lookup,
-        object_lookup,
         attribute,
         filter_object_type,
         filter_event_type,
@@ -103,9 +127,7 @@ pub fn collect_case_attribute_kpi_values(
 
 /// One optional KPI value per case index (None when the case has no computable value).
 pub fn collect_per_case_attribute_kpi_values(
-    cases: &[CaseEntry],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-    object_lookup: &FxHashMap<String, &OCELObject>,
+    cases: &[OCEL],
     attribute: &str,
     filter_object_type: Option<&str>,
     filter_event_type: Option<&str>,
@@ -113,12 +135,9 @@ pub fn collect_per_case_attribute_kpi_values(
 ) -> Vec<Option<f64>> {
     cases
         .iter()
-        .map(|(event_ids, object_ids, _)| {
+        .map(|case| {
             let case_values = collect_case_attribute_values(
-                event_ids,
-                object_ids,
-                event_lookup,
-                object_lookup,
+                case,
                 attribute,
                 filter_object_type,
                 filter_event_type,
@@ -130,9 +149,7 @@ pub fn collect_per_case_attribute_kpi_values(
 
 /// One combined KPI value per case.
 pub fn collect_case_attribute_combination_values(
-    cases: &[CaseEntry],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-    object_lookup: &FxHashMap<String, &OCELObject>,
+    cases: &[OCEL],
     left_attribute: &str,
     left_object_type: Option<&str>,
     left_event_type: Option<&str>,
@@ -145,8 +162,6 @@ pub fn collect_case_attribute_combination_values(
 ) -> CaseKpiValues {
     case_kpi_values_from_per_case(collect_per_case_attribute_combination_values(
         cases,
-        event_lookup,
-        object_lookup,
         left_attribute,
         left_object_type,
         left_event_type,
@@ -161,9 +176,7 @@ pub fn collect_case_attribute_combination_values(
 
 /// One optional combined KPI value per case index.
 pub fn collect_per_case_attribute_combination_values(
-    cases: &[CaseEntry],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-    object_lookup: &FxHashMap<String, &OCELObject>,
+    cases: &[OCEL],
     left_attribute: &str,
     left_object_type: Option<&str>,
     left_event_type: Option<&str>,
@@ -176,21 +189,15 @@ pub fn collect_per_case_attribute_combination_values(
 ) -> Vec<Option<f64>> {
     cases
         .iter()
-        .map(|(event_ids, object_ids, _)| {
+        .map(|case| {
             let left_raw = collect_case_attribute_values(
-                event_ids,
-                object_ids,
-                event_lookup,
-                object_lookup,
+                case,
                 left_attribute,
                 left_object_type,
                 left_event_type,
             );
             let right_raw = collect_case_attribute_values(
-                event_ids,
-                object_ids,
-                event_lookup,
-                object_lookup,
+                case,
                 right_attribute,
                 right_object_type,
                 right_event_type,
@@ -216,46 +223,15 @@ pub fn collect_per_case_attribute_combination_values(
 
 /// Raw `from → to` transition durations for one case across object timelines.
 fn collect_case_time_transition_durations(
-    event_ids: &[String],
-    object_ids: &[String],
-    arches: &[(String, String)],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-    object_lookup: &FxHashMap<String, &OCELObject>,
+    case: &OCEL,
     object_type: &str,
     from_activity: &str,
     to_activity: &str,
 ) -> Vec<f64> {
     let mut durations: Vec<f64> = Vec::new();
-    let event_set: FxHashSet<&str> = event_ids.iter().map(String::as_str).collect();
-    let object_set: FxHashSet<&str> = object_ids.iter().map(String::as_str).collect();
+    let object_timelines = build_object_timelines(case, object_type);
 
-    let mut object_timelines: FxHashMap<
-        &str,
-        Vec<(chrono::DateTime<chrono::FixedOffset>, &str)>,
-    > = FxHashMap::default();
-
-    for (ev_id, obj_id) in arches {
-        if !event_set.contains(ev_id.as_str()) || !object_set.contains(obj_id.as_str()) {
-            continue;
-        }
-        if let Some(obj) = object_lookup.get(obj_id.as_str()) {
-            if obj.object_type != object_type {
-                continue;
-            }
-        } else {
-            continue;
-        }
-        if let Some(event) = event_lookup.get(ev_id.as_str()) {
-            object_timelines
-                .entry(obj_id.as_str())
-                .or_default()
-                .push((event.time, event.event_type.as_str()));
-        }
-    }
-
-    for timeline in object_timelines.values_mut() {
-        timeline.sort_by_key(|(t, _)| *t);
-
+    for timeline in object_timelines.values() {
         let mut i = 0;
         while i < timeline.len() {
             if timeline[i].1 != from_activity {
@@ -285,9 +261,7 @@ fn collect_case_time_transition_durations(
 
 /// One aggregated `from → to` time (seconds) per case (`intra_case_agg` required).
 pub fn collect_case_time_values(
-    cases: &[CaseEntry],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-    object_lookup: &FxHashMap<String, &OCELObject>,
+    cases: &[OCEL],
     object_type: &str,
     from_activity: &str,
     to_activity: &str,
@@ -295,8 +269,6 @@ pub fn collect_case_time_values(
 ) -> CaseKpiValues {
     case_kpi_values_from_per_case(collect_per_case_time_values(
         cases,
-        event_lookup,
-        object_lookup,
         object_type,
         from_activity,
         to_activity,
@@ -306,9 +278,7 @@ pub fn collect_case_time_values(
 
 /// One optional aggregated time per case index.
 pub fn collect_per_case_time_values(
-    cases: &[CaseEntry],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-    object_lookup: &FxHashMap<String, &OCELObject>,
+    cases: &[OCEL],
     object_type: &str,
     from_activity: &str,
     to_activity: &str,
@@ -316,13 +286,9 @@ pub fn collect_per_case_time_values(
 ) -> Vec<Option<f64>> {
     cases
         .iter()
-        .map(|(event_ids, object_ids, arches)| {
+        .map(|case| {
             let raw = collect_case_time_transition_durations(
-                event_ids,
-                object_ids,
-                arches,
-                event_lookup,
-                object_lookup,
+                case,
                 object_type,
                 from_activity,
                 to_activity,
@@ -335,35 +301,15 @@ pub fn collect_per_case_time_values(
 /// Returns, for each activity, the set of activities that follow it within
 /// the timelines of objects matching `object_type`.
 pub fn compute_activity_successors(
-    cases: &[CaseEntry],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-    object_lookup: &FxHashMap<String, &OCELObject>,
+    cases: &[OCEL],
     object_type: &str,
 ) -> FxHashMap<String, Vec<String>> {
     let mut raw: FxHashMap<String, FxHashSet<String>> = FxHashMap::default();
 
-    for (_event_ids, _object_ids, arches) in cases {
-        let mut object_timelines: FxHashMap<
-            &str,
-            Vec<(chrono::DateTime<chrono::FixedOffset>, &str)>,
-        > = FxHashMap::default();
+    for case in cases {
+        let object_timelines = build_object_timelines(case, object_type);
 
-        for (ev_id, obj_id) in arches {
-            match object_lookup.get(obj_id.as_str()) {
-                Some(obj) if obj.object_type == object_type => {}
-                _ => continue,
-            }
-            if let Some(event) = event_lookup.get(ev_id.as_str()) {
-                object_timelines
-                    .entry(obj_id.as_str())
-                    .or_default()
-                    .push((event.time, event.event_type.as_str()));
-            }
-        }
-
-        for timeline in object_timelines.values_mut() {
-            timeline.sort_by_key(|(t, _)| *t);
-
+        for timeline in object_timelines.values() {
             for i in 0..timeline.len() {
                 let from = timeline[i].1;
                 for j in (i + 1)..timeline.len() {
@@ -388,25 +334,16 @@ pub fn compute_activity_successors(
 }
 
 /// One duration (seconds) per case with at least two events.
-pub fn collect_case_duration_values(
-    cases: &[CaseEntry],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-) -> CaseKpiValues {
-    case_kpi_values_from_per_case(collect_per_case_duration_values(cases, event_lookup))
+pub fn collect_case_duration_values(cases: &[OCEL]) -> CaseKpiValues {
+    case_kpi_values_from_per_case(collect_per_case_duration_values(cases))
 }
 
 /// One optional duration (seconds) per case index.
-pub fn collect_per_case_duration_values(
-    cases: &[CaseEntry],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-) -> Vec<Option<f64>> {
+pub fn collect_per_case_duration_values(cases: &[OCEL]) -> Vec<Option<f64>> {
     cases
         .iter()
-        .map(|(event_ids, _, _)| {
-            let mut times: Vec<_> = event_ids
-                .iter()
-                .filter_map(|id| event_lookup.get(id).map(|e| e.time))
-                .collect();
+        .map(|case| {
+            let mut times: Vec<_> = case.events.iter().map(|e| e.time).collect();
             times.sort();
 
             if times.len() >= 2 {

--- a/backend/src/core/kpi/histogram_filtering.rs
+++ b/backend/src/core/kpi/histogram_filtering.rs
@@ -1,11 +1,10 @@
 use crate::core::kpi::case_kpis::{
     collect_per_case_attribute_combination_values, collect_per_case_attribute_kpi_values,
-    collect_per_case_duration_values, collect_per_case_time_values, CaseEntry,
+    collect_per_case_duration_values, collect_per_case_time_values,
 };
 use crate::core::kpi::validation::{validate_attribute_source, validate_intra_case_agg};
 use crate::models::kpi::{KpiFilterSpec, KpiHistogramFilterPayload};
-use crate::models::ocel::{OCELEvent, OCELObject};
-use rustc_hash::FxHashMap;
+use crate::models::ocel::OCEL;
 
 fn value_in_ranges(value: f64, ranges: &[[f64; 2]], max_value: f64) -> bool {
     ranges.iter().any(|&[start, end]| {
@@ -17,16 +16,16 @@ fn value_in_ranges(value: f64, ranges: &[[f64; 2]], max_value: f64) -> bool {
     })
 }
 
-fn filter_cases_by_per_case_values(
-    cases: &[CaseEntry],
+fn kept_case_indices_by_per_case_values(
+    total_cases: usize,
     per_case_values: &[Option<f64>],
     value_ranges: &[[f64; 2]],
-) -> Result<Vec<CaseEntry>, String> {
+) -> Result<Vec<usize>, String> {
     if value_ranges.is_empty() {
         return Err("At least one value range is required".to_string());
     }
-    if per_case_values.len() != cases.len() {
-        return Err("Per-case KPI values do not align with case notion entries".to_string());
+    if per_case_values.len() != total_cases {
+        return Err("Per-case KPI values do not align with case OCEL entries".to_string());
     }
 
     let max_value = per_case_values
@@ -34,27 +33,25 @@ fn filter_cases_by_per_case_values(
         .filter_map(|v| *v)
         .fold(f64::NEG_INFINITY, f64::max);
 
-    let filtered = cases
+    let kept = per_case_values
         .iter()
-        .zip(per_case_values.iter())
-        .filter_map(|(case_entry, value)| {
+        .enumerate()
+        .filter_map(|(index, value)| {
             value
                 .filter(|v| value_in_ranges(*v, value_ranges, max_value))
-                .map(|_| case_entry.clone())
+                .map(|_| index)
         })
         .collect();
 
-    Ok(filtered)
+    Ok(kept)
 }
 
 fn collect_per_case_values_for_filter(
-    cases: &[CaseEntry],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-    object_lookup: &FxHashMap<String, &OCELObject>,
+    cases: &[OCEL],
     filter: &KpiFilterSpec,
 ) -> Result<Vec<Option<f64>>, String> {
     match filter {
-        KpiFilterSpec::CaseDuration => Ok(collect_per_case_duration_values(cases, event_lookup)),
+        KpiFilterSpec::CaseDuration => Ok(collect_per_case_duration_values(cases)),
         KpiFilterSpec::CaseAttribute {
             attribute,
             object_type,
@@ -65,8 +62,6 @@ fn collect_per_case_values_for_filter(
             validate_intra_case_agg(intra_case_agg, "intra_case_agg")?;
             Ok(collect_per_case_attribute_kpi_values(
                 cases,
-                event_lookup,
-                object_lookup,
                 attribute,
                 object_type.as_deref(),
                 event_type.as_deref(),
@@ -90,8 +85,6 @@ fn collect_per_case_values_for_filter(
             validate_intra_case_agg(right_intra_case_agg, "right_intra_case_agg")?;
             Ok(collect_per_case_attribute_combination_values(
                 cases,
-                event_lookup,
-                object_lookup,
                 left_attribute,
                 left_object_type.as_deref(),
                 left_event_type.as_deref(),
@@ -112,8 +105,6 @@ fn collect_per_case_values_for_filter(
             validate_intra_case_agg(intra_case_agg, "intra_case_agg")?;
             Ok(collect_per_case_time_values(
                 cases,
-                event_lookup,
-                object_lookup,
                 object_type,
                 from_activity,
                 to_activity,
@@ -123,27 +114,23 @@ fn collect_per_case_values_for_filter(
     }
 }
 
-/// Applies a KPI histogram filter and returns matching case notion entries.
-pub fn filter_case_notion_by_kpi_histogram(
-    cases: &[CaseEntry],
-    event_lookup: &FxHashMap<String, &OCELEvent>,
-    object_lookup: &FxHashMap<String, &OCELObject>,
+/// Applies a KPI histogram filter and returns the indices of the case OCELs that
+/// fall within the selected value ranges (indices align with the input `cases`).
+pub fn filter_case_indices_by_kpi_histogram(
+    cases: &[OCEL],
     payload: &KpiHistogramFilterPayload,
-) -> Result<Vec<CaseEntry>, String> {
-    let per_case_values = collect_per_case_values_for_filter(
-        cases,
-        event_lookup,
-        object_lookup,
-        &payload.kpi_filter,
-    )?;
+) -> Result<Vec<usize>, String> {
+    let per_case_values = collect_per_case_values_for_filter(cases, &payload.kpi_filter)?;
 
-    let filtered = filter_cases_by_per_case_values(cases, &per_case_values, &payload.value_ranges)?;
+    let kept =
+        kept_case_indices_by_per_case_values(cases.len(), &per_case_values, &payload.value_ranges)?;
 
-    if filtered.is_empty() {
+    if kept.is_empty() {
         return Err(
-            "Filter produced an empty case notion; widen the selected histogram bins".to_string(),
+            "Filter produced an empty case OCEL collection; widen the selected histogram bins"
+                .to_string(),
         );
     }
 
-    Ok(filtered)
+    Ok(kept)
 }

--- a/backend/src/core/kpi/metadata.rs
+++ b/backend/src/core/kpi/metadata.rs
@@ -1,0 +1,118 @@
+use crate::models::kpi::{
+    AttributeMetadata, EventTypeMetadata, ObjectTypeMetadata,
+};
+use crate::models::ocel::{OCEL, OCELType};
+use std::collections::HashMap;
+
+pub struct TypeMeta {
+    pub total_events: usize,
+    pub total_objects: usize,
+    pub object_types: Vec<ObjectTypeMetadata>,
+    pub event_types: Vec<EventTypeMetadata>,
+}
+
+fn attrs_from_type(ocel_type: &OCELType) -> Vec<AttributeMetadata> {
+    let mut attrs: Vec<AttributeMetadata> = ocel_type
+        .attributes
+        .iter()
+        .map(|a| AttributeMetadata {
+            name: a.name.clone(),
+            value_type: a.value_type.clone(),
+            numeric: a.value_type == "integer" || a.value_type == "float",
+        })
+        .collect();
+    attrs.sort_by(|a, b| a.name.cmp(&b.name));
+    attrs
+}
+
+fn remember_type(
+    bucket: &mut HashMap<String, HashMap<String, AttributeMetadata>>,
+    types: &[OCELType],
+) {
+    for t in types {
+        let attrs = bucket.entry(t.name.clone()).or_default();
+        for a in &t.attributes {
+            attrs.entry(a.name.clone()).or_insert_with(|| AttributeMetadata {
+                name: a.name.clone(),
+                value_type: a.value_type.clone(),
+                numeric: a.value_type == "integer" || a.value_type == "float",
+            });
+        }
+    }
+}
+
+fn sorted_attrs(attrs: HashMap<String, AttributeMetadata>) -> Vec<AttributeMetadata> {
+    let mut list: Vec<_> = attrs.into_values().collect();
+    list.sort_by(|a, b| a.name.cmp(&b.name));
+    list
+}
+
+/// Types from a single OCEL (full log schema).
+pub fn types_from_ocel(ocel: &OCEL) -> TypeMeta {
+    let mut object_types: Vec<ObjectTypeMetadata> = ocel
+        .object_types
+        .iter()
+        .map(|ot| ObjectTypeMetadata {
+            name: ot.name.clone(),
+            attributes: attrs_from_type(ot),
+        })
+        .collect();
+    object_types.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut event_types: Vec<EventTypeMetadata> = ocel
+        .event_types
+        .iter()
+        .map(|et| EventTypeMetadata {
+            name: et.name.clone(),
+            attributes: attrs_from_type(et),
+        })
+        .collect();
+    event_types.sort_by(|a, b| a.name.cmp(&b.name));
+
+    TypeMeta {
+        total_events: ocel.events.len(),
+        total_objects: ocel.objects.len(),
+        object_types,
+        event_types,
+    }
+}
+
+/// Union of object/event types across all cases in a collection.
+pub fn types_from_cases(cases: &[OCEL]) -> TypeMeta {
+    let mut object_bucket: HashMap<String, HashMap<String, AttributeMetadata>> = HashMap::new();
+    let mut event_bucket: HashMap<String, HashMap<String, AttributeMetadata>> = HashMap::new();
+    let mut total_events = 0;
+    let mut total_objects = 0;
+
+    for case in cases {
+        total_events += case.events.len();
+        total_objects += case.objects.len();
+        remember_type(&mut object_bucket, &case.object_types);
+        remember_type(&mut event_bucket, &case.event_types);
+    }
+
+    let mut object_types: Vec<ObjectTypeMetadata> = object_bucket
+        .into_iter()
+        .map(|(name, attrs)| ObjectTypeMetadata {
+            name,
+            attributes: sorted_attrs(attrs),
+        })
+        .collect();
+    object_types.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut event_types: Vec<EventTypeMetadata> = event_bucket
+        .into_iter()
+        .map(|(name, attrs)| EventTypeMetadata {
+            name,
+            attributes: sorted_attrs(attrs),
+        })
+        .collect();
+    event_types.sort_by(|a, b| a.name.cmp(&b.name));
+
+    TypeMeta {
+        total_events,
+        total_objects,
+        object_types,
+        event_types,
+    }
+}

--- a/backend/src/core/kpi/mod.rs
+++ b/backend/src/core/kpi/mod.rs
@@ -2,4 +2,5 @@ pub mod attribute_stats;
 pub mod case_kpis;
 pub mod histogram;
 pub mod histogram_filtering;
+pub mod metadata;
 pub mod validation;

--- a/backend/src/core/kpi/validation.rs
+++ b/backend/src/core/kpi/validation.rs
@@ -1,4 +1,4 @@
-pub const VALID_INTRA_CASE_AGG: &[&str] = &["sum", "mean", "min", "max", "count"];
+const VALID_INTRA_CASE_AGG: &[&str] = &["sum", "mean", "min", "max", "count"];
 
 pub fn validate_attribute_source(
     object_type: &Option<String>,

--- a/backend/src/handlers/kpi.rs
+++ b/backend/src/handlers/kpi.rs
@@ -1,19 +1,20 @@
 use crate::core::kpi::histogram_filtering::filter_case_indices_by_kpi_histogram;
 use crate::core::kpi::attribute_stats::compute_numeric_stats;
 use crate::core::kpi::histogram::{build_range_histogram, default_bin_count};
+use crate::core::kpi::metadata::{types_from_cases, types_from_ocel};
 use crate::core::kpi::validation::{validate_attribute_source, validate_intra_case_agg};
 use crate::core::kpi::case_kpis::{
     collect_case_attribute_combination_values, collect_case_attribute_kpi_values,
     collect_case_duration_values, collect_case_time_values, compute_activity_successors,
 };
 use crate::models::kpi::{
-    ActivitySuccessorsQuery, ActivitySuccessorsResponse, AttributeMetadata,
+    ActivitySuccessorsQuery, ActivitySuccessorsResponse,
     CaseAttributeCombinationRequest, CaseAttributeCombinationStatsResponse, CaseAttributeQuery,
-    CaseAttributeStatsResponse, CaseDurationQuery, CaseDurationResponse,
-    CaseTimeQuery, CaseTimeStatsResponse, EventTypeMetadata,
-    KpiHistogramBin, KpiHistogramFilterPayload, ObjectTypeMetadata, OcelMetadataResponse,
+    CaseAttributeStatsResponse, CaseDurationQuery, CaseDurationResponse, CaseOcelMetadataResponse,
+    CaseTimeQuery, CaseTimeStatsResponse, KpiHistogramBin, KpiHistogramFilterPayload,
+    OcelMetadataResponse,
 };
-use crate::models::ocel::{OCEL, OCELType};
+use crate::models::ocel::OCEL;
 use crate::models::ocel_collection::OCELCollection;
 use crate::traits::import_export::ImportableFromPath;
 use axum::{
@@ -73,58 +74,48 @@ async fn load_kpi_context(
     })
 }
 
-// Builds attribute metadata for a single OCELType.
-fn build_attribute_metadata(ocel_type: &OCELType) -> Vec<AttributeMetadata> {
-    let mut attrs: Vec<AttributeMetadata> = ocel_type
-        .attributes
-        .iter()
-        .map(|a| AttributeMetadata {
-            name: a.name.clone(),
-            value_type: a.value_type.clone(),
-            numeric: a.value_type == "integer" || a.value_type == "float",
-        })
-        .collect();
-    attrs.sort_by(|a, b| a.name.cmp(&b.name));
-    attrs
-}
-
-/// Returns all object/event types with their attributes.
-/// Use this to build UI dropdowns before calling KPI endpoints.
+/// Dropdown metadata from the original OCEL.
 pub async fn get_ocel_metadata(Path(file_id): Path<String>) -> impl IntoResponse {
     let ocel = match OCEL::import_from_path(&file_id).await {
         Ok(ocel) => ocel,
         Err((status, message)) => return (status, message).into_response(),
     };
 
-    let mut object_types: Vec<ObjectTypeMetadata> = ocel
-        .object_types
-        .iter()
-        .map(|ot| ObjectTypeMetadata {
-            name: ot.name.clone(),
-            attributes: build_attribute_metadata(ot),
-        })
-        .collect();
-    object_types.sort_by(|a, b| a.name.cmp(&b.name));
+    let meta = types_from_ocel(&ocel);
+    (
+        StatusCode::OK,
+        Json(OcelMetadataResponse {
+            file_id,
+            total_events: meta.total_events,
+            total_objects: meta.total_objects,
+            object_types: meta.object_types,
+            event_types: meta.event_types,
+        }),
+    )
+        .into_response()
+}
 
-    let mut event_types: Vec<EventTypeMetadata> = ocel
-        .event_types
-        .iter()
-        .map(|et| EventTypeMetadata {
-            name: et.name.clone(),
-            attributes: build_attribute_metadata(et),
-        })
-        .collect();
-    event_types.sort_by(|a, b| a.name.cmp(&b.name));
-
-    let response = OcelMetadataResponse {
-        file_id,
-        total_events: ocel.events.len(),
-        total_objects: ocel.objects.len(),
-        object_types,
-        event_types,
+/// Dropdown metadata from the case ocel collection.
+pub async fn get_case_ocel_metadata(
+    Path(case_ocels_file_id): Path<String>,
+) -> impl IntoResponse {
+    let ctx = match load_kpi_context(&case_ocels_file_id).await {
+        Ok(ctx) => ctx,
+        Err(response) => return response,
     };
 
-    (StatusCode::OK, Json(response)).into_response()
+    let meta = types_from_cases(&ctx.collection.ocels);
+    (
+        StatusCode::OK,
+        Json(CaseOcelMetadataResponse {
+            case_ocels_file_id,
+            total_events: meta.total_events,
+            total_objects: meta.total_objects,
+            object_types: meta.object_types,
+            event_types: meta.event_types,
+        }),
+    )
+        .into_response()
 }
 
 /// Returns histogram data when `histogram=true`; bin count is automatic.

--- a/backend/src/handlers/kpi.rs
+++ b/backend/src/handlers/kpi.rs
@@ -75,8 +75,8 @@ async fn load_kpi_context(
 }
 
 /// Dropdown metadata from the original OCEL.
-pub async fn get_ocel_metadata(Path(file_id): Path<String>) -> impl IntoResponse {
-    let ocel = match OCEL::import_from_path(&file_id).await {
+pub async fn get_ocel_metadata(Path(ocel_file_id): Path<String>) -> impl IntoResponse {
+    let ocel = match OCEL::import_from_path(&ocel_file_id).await {
         Ok(ocel) => ocel,
         Err((status, message)) => return (status, message).into_response(),
     };
@@ -85,7 +85,7 @@ pub async fn get_ocel_metadata(Path(file_id): Path<String>) -> impl IntoResponse
     (
         StatusCode::OK,
         Json(OcelMetadataResponse {
-            file_id,
+            ocel_file_id,
             total_events: meta.total_events,
             total_objects: meta.total_objects,
             object_types: meta.object_types,

--- a/backend/src/handlers/kpi.rs
+++ b/backend/src/handlers/kpi.rs
@@ -1,4 +1,4 @@
-use crate::core::kpi::histogram_filtering::filter_case_notion_by_kpi_histogram;
+use crate::core::kpi::histogram_filtering::filter_case_indices_by_kpi_histogram;
 use crate::core::kpi::attribute_stats::compute_numeric_stats;
 use crate::core::kpi::histogram::{build_range_histogram, default_bin_count};
 use crate::core::kpi::validation::{validate_attribute_source, validate_intra_case_agg};
@@ -13,74 +13,64 @@ use crate::models::kpi::{
     CaseTimeQuery, CaseTimeStatsResponse, EventTypeMetadata,
     KpiHistogramBin, KpiHistogramFilterPayload, ObjectTypeMetadata, OcelMetadataResponse,
 };
-use crate::models::ocel::{OCEL, OCELEvent, OCELObject, OCELType};
+use crate::models::ocel::{OCEL, OCELType};
+use crate::models::ocel_collection::OCELCollection;
 use crate::traits::import_export::ImportableFromPath;
-use async_trait::async_trait;
 use axum::{
     Json,
     extract::{Path, Query},
     http::StatusCode,
     response::IntoResponse,
 };
-use rustc_hash::FxHashMap;
+use serde_json::Value;
+use std::collections::HashMap;
 use tokio::fs as tokio_fs;
 use uuid::Uuid;
-use serde::{Deserialize, Serialize};
 
-type RawCaseNotionEntry = (Vec<String>, Vec<String>, Vec<(String, String)>);
-
-#[derive(Deserialize, Serialize)]
-struct PersistedCaseNotion {
-    case_notion: Vec<RawCaseNotionEntry>,
+// A KPI request is keyed by a stored case OCEL collection (`case_ocels_{id}.json`),
+// where every case is a self-contained OCEL. KPIs are computed directly on those
+// per-case OCELs (`collection.ocels`).
+struct KpiLoaded {
+    collection: OCELCollection,
     origin_file_id_ocel: String,
     case_notion_type: String,
-    // Present in the JSON file but not needed by any KPI handler.
-    #[allow(dead_code)]
-    object_type: Option<String>,
-    #[allow(dead_code)]
-    case_notion_file_id: String,
 }
 
-#[async_trait]
-impl ImportableFromPath for PersistedCaseNotion {
-    async fn import_from_path(file_id: &str) -> Result<Self, (StatusCode, String)> {
-        let path = format!("./temp/case_notion_{}.json", file_id);
-        Self::from_json_file(&path).await
-    }
-}
-
-// Shared helper: load a persisted case notion or return a clean 404.
-async fn load_case_notion(
-    case_notion_file_id: &str,
-) -> Result<PersistedCaseNotion, axum::response::Response> {
-    match PersistedCaseNotion::import_from_path(case_notion_file_id).await {
-        Ok(data) => Ok(data),
-        Err((status, _)) if status == StatusCode::NOT_FOUND => Err((
-            StatusCode::NOT_FOUND,
-            format!(
-                "No stored case notion found for fileId: {}",
-                case_notion_file_id
-            ),
-        )
-            .into_response()),
-        Err((status, message)) => Err((status, message).into_response()),
-    }
-}
-
-struct KpiLoaded {
-    persisted: PersistedCaseNotion,
-    ocel: OCEL,
+fn collection_attr_string(attributes: &HashMap<String, Value>, key: &str) -> Option<String> {
+    attributes
+        .get(key)
+        .and_then(|value| value.as_str())
+        .map(|value| value.to_string())
 }
 
 async fn load_kpi_context(
-    case_notion_file_id: &str,
+    case_ocels_file_id: &str,
 ) -> Result<KpiLoaded, axum::response::Response> {
-    let persisted = load_case_notion(case_notion_file_id).await?;
-    let ocel = match OCEL::import_from_path(&persisted.origin_file_id_ocel).await {
-        Ok(ocel) => ocel,
+    let collection = match OCELCollection::import_from_path(case_ocels_file_id).await {
+        Ok(collection) => collection,
+        Err((status, _)) if status == StatusCode::NOT_FOUND => {
+            return Err((
+                StatusCode::NOT_FOUND,
+                format!(
+                    "No stored case OCEL collection found for fileId: {}",
+                    case_ocels_file_id
+                ),
+            )
+                .into_response());
+        }
         Err((status, message)) => return Err((status, message).into_response()),
     };
-    Ok(KpiLoaded { persisted, ocel })
+
+    let origin_file_id_ocel =
+        collection_attr_string(&collection.attributes, "origin_file_id_ocel").unwrap_or_default();
+    let case_notion_type =
+        collection_attr_string(&collection.attributes, "case_notion_type").unwrap_or_default();
+
+    Ok(KpiLoaded {
+        collection,
+        origin_file_id_ocel,
+        case_notion_type,
+    })
 }
 
 // Builds attribute metadata for a single OCELType.
@@ -137,17 +127,6 @@ pub async fn get_ocel_metadata(Path(file_id): Path<String>) -> impl IntoResponse
     (StatusCode::OK, Json(response)).into_response()
 }
 
-fn ocel_lookups(
-    ocel: &OCEL,
-) -> (
-    FxHashMap<String, &OCELEvent>,
-    FxHashMap<String, &OCELObject>,
-) {
-    let event_lookup = ocel.events.iter().map(|e| (e.id.clone(), e)).collect();
-    let object_lookup = ocel.objects.iter().map(|o| (o.id.clone(), o)).collect();
-    (event_lookup, object_lookup)
-}
-
 /// Returns histogram data when `histogram=true`; bin count is automatic.
 fn optional_histogram(
     values: &[f64],
@@ -164,7 +143,7 @@ fn optional_histogram(
 /// One aggregated KPI value per case (`intra_case_agg` required).
 /// Add `?histogram=true` to get histogram data alongside stats.
 pub async fn get_case_attribute_stats(
-    Path(case_notion_file_id): Path<String>,
+    Path(case_ocels_file_id): Path<String>,
     Query(query): Query<CaseAttributeQuery>,
 ) -> impl IntoResponse {
     if let Err(message) = validate_attribute_source(&query.object_type, &query.event_type, "query")
@@ -176,16 +155,13 @@ pub async fn get_case_attribute_stats(
         return (StatusCode::BAD_REQUEST, message).into_response();
     }
 
-    let ctx = match load_kpi_context(&case_notion_file_id).await {
+    let ctx = match load_kpi_context(&case_ocels_file_id).await {
         Ok(ctx) => ctx,
         Err(response) => return response,
     };
-    let (event_lookup, object_lookup) = ocel_lookups(&ctx.ocel);
 
     let result = collect_case_attribute_kpi_values(
-        &ctx.persisted.case_notion,
-        &event_lookup,
-        &object_lookup,
+        &ctx.collection.ocels,
         &query.attribute,
         query.object_type.as_deref(),
         query.event_type.as_deref(),
@@ -196,9 +172,9 @@ pub async fn get_case_attribute_stats(
     let (bins_used, histogram) = optional_histogram(&result.values, query.histogram);
 
     (StatusCode::OK, Json(CaseAttributeStatsResponse {
-        case_notion_file_id,
-        origin_file_id_ocel: ctx.persisted.origin_file_id_ocel,
-        case_notion_type: ctx.persisted.case_notion_type,
+        case_ocels_file_id,
+        origin_file_id_ocel: ctx.origin_file_id_ocel,
+        case_notion_type: ctx.case_notion_type,
         attribute: query.attribute,
         intra_case_agg: query.intra_case_agg,
         cases_with_value: result.values.len(),
@@ -212,7 +188,7 @@ pub async fn get_case_attribute_stats(
 
 /// Combines two per-case attribute operands, then returns stats over the results.
 pub async fn post_attribute_combination(
-    Path(case_notion_file_id): Path<String>,
+    Path(case_ocels_file_id): Path<String>,
     Json(payload): Json<CaseAttributeCombinationRequest>,
 ) -> impl IntoResponse {
     if let Err(message) =
@@ -238,16 +214,13 @@ pub async fn post_attribute_combination(
         return (StatusCode::BAD_REQUEST, message).into_response();
     }
 
-    let ctx = match load_kpi_context(&case_notion_file_id).await {
+    let ctx = match load_kpi_context(&case_ocels_file_id).await {
         Ok(ctx) => ctx,
         Err(response) => return response,
     };
-    let (event_lookup, object_lookup) = ocel_lookups(&ctx.ocel);
 
     let result = collect_case_attribute_combination_values(
-        &ctx.persisted.case_notion,
-        &event_lookup,
-        &object_lookup,
+        &ctx.collection.ocels,
         &payload.left_attribute,
         payload.left_object_type.as_deref(),
         payload.left_event_type.as_deref(),
@@ -265,9 +238,9 @@ pub async fn post_attribute_combination(
     (
         StatusCode::OK,
         Json(CaseAttributeCombinationStatsResponse {
-            case_notion_file_id,
-            origin_file_id_ocel: ctx.persisted.origin_file_id_ocel,
-            case_notion_type: ctx.persisted.case_notion_type,
+            case_ocels_file_id,
+            origin_file_id_ocel: ctx.origin_file_id_ocel,
+            case_notion_type: ctx.case_notion_type,
             operation: payload.operation,
             cases_with_value: result.values.len(),
             cases_skipped: result.cases_skipped,
@@ -282,23 +255,20 @@ pub async fn post_attribute_combination(
 /// Measures elapsed time (seconds) between two activities per object lifecycle,
 /// aggregated to one value per case (`intra_case_agg` required).
 pub async fn get_case_time_stats(
-    Path(case_notion_file_id): Path<String>,
+    Path(case_ocels_file_id): Path<String>,
     Query(query): Query<CaseTimeQuery>,
 ) -> impl IntoResponse {
     if let Err(message) = validate_intra_case_agg(&query.intra_case_agg, "intra_case_agg") {
         return (StatusCode::BAD_REQUEST, message).into_response();
     }
 
-    let ctx = match load_kpi_context(&case_notion_file_id).await {
+    let ctx = match load_kpi_context(&case_ocels_file_id).await {
         Ok(ctx) => ctx,
         Err(response) => return response,
     };
-    let (event_lookup, object_lookup) = ocel_lookups(&ctx.ocel);
 
     let result = collect_case_time_values(
-        &ctx.persisted.case_notion,
-        &event_lookup,
-        &object_lookup,
+        &ctx.collection.ocels,
         &query.object_type,
         &query.from_activity,
         &query.to_activity,
@@ -309,9 +279,9 @@ pub async fn get_case_time_stats(
     let (bins_used, histogram) = optional_histogram(&result.values, query.histogram);
 
     (StatusCode::OK, Json(CaseTimeStatsResponse {
-        case_notion_file_id,
-        origin_file_id_ocel: ctx.persisted.origin_file_id_ocel,
-        case_notion_type: ctx.persisted.case_notion_type,
+        case_ocels_file_id,
+        origin_file_id_ocel: ctx.origin_file_id_ocel,
+        case_notion_type: ctx.case_notion_type,
         object_type: query.object_type,
         from_activity: query.from_activity,
         to_activity: query.to_activity,
@@ -325,33 +295,27 @@ pub async fn get_case_time_stats(
     .into_response()
 }
 
-/// `GET /v1/kpi/activity_successors/{case_notion_file_id}?object_type=...`
+/// `GET /v1/kpi/activity_successors/{case_ocels_file_id}?object_type=...`
 /// Returns successor activities within that object type's timelines only.
 /// Use this to populate the `to_activity` dropdown for `case_time_stats`.
 pub async fn get_activity_successors(
-    Path(case_notion_file_id): Path<String>,
+    Path(case_ocels_file_id): Path<String>,
     Query(query): Query<ActivitySuccessorsQuery>,
 ) -> impl IntoResponse {
-    let ctx = match load_kpi_context(&case_notion_file_id).await {
+    let ctx = match load_kpi_context(&case_ocels_file_id).await {
         Ok(ctx) => ctx,
         Err(response) => return response,
     };
-    let (event_lookup, object_lookup) = ocel_lookups(&ctx.ocel);
 
-    let successors = compute_activity_successors(
-        &ctx.persisted.case_notion,
-        &event_lookup,
-        &object_lookup,
-        &query.object_type,
-    )
-    .into_iter()
-    .collect();
+    let successors = compute_activity_successors(&ctx.collection.ocels, &query.object_type)
+        .into_iter()
+        .collect();
 
     (
         StatusCode::OK,
         Json(ActivitySuccessorsResponse {
-            case_notion_file_id,
-            case_notion_type: ctx.persisted.case_notion_type,
+            case_ocels_file_id,
+            case_notion_type: ctx.case_notion_type,
             successors,
         }),
     )
@@ -360,23 +324,22 @@ pub async fn get_activity_successors(
 
 /// Returns aggregate stats over all case durations (first event → last event).
 pub async fn get_case_duration(
-    Path(case_notion_file_id): Path<String>,
+    Path(case_ocels_file_id): Path<String>,
     Query(query): Query<CaseDurationQuery>,
 ) -> impl IntoResponse {
-    let ctx = match load_kpi_context(&case_notion_file_id).await {
+    let ctx = match load_kpi_context(&case_ocels_file_id).await {
         Ok(ctx) => ctx,
         Err(response) => return response,
     };
-    let (event_lookup, _object_lookup) = ocel_lookups(&ctx.ocel);
 
-    let result = collect_case_duration_values(&ctx.persisted.case_notion, &event_lookup);
+    let result = collect_case_duration_values(&ctx.collection.ocels);
     let stats = compute_numeric_stats(&result.values);
     let (bins_used, histogram) = optional_histogram(&result.values, query.histogram);
 
     (StatusCode::OK, Json(CaseDurationResponse {
-        case_notion_file_id,
-        origin_file_id_ocel: ctx.persisted.origin_file_id_ocel,
-        case_notion_type: ctx.persisted.case_notion_type,
+        case_ocels_file_id,
+        origin_file_id_ocel: ctx.origin_file_id_ocel,
+        case_notion_type: ctx.case_notion_type,
         cases_with_duration: result.values.len(),
         cases_skipped: result.cases_skipped,
         stats,
@@ -386,63 +349,76 @@ pub async fn get_case_duration(
     .into_response()
 }
 
-async fn persist_filtered_case_notion(
-    cases: &[RawCaseNotionEntry],
-    persisted: &PersistedCaseNotion,
+/// Persist the case OCELs at `kept_indices` as a new collection, carrying over
+/// the source collection's metadata so subsequent KPI calls behave identically.
+async fn persist_filtered_case_ocels(
+    collection: &OCELCollection,
+    kept_indices: &[usize],
+    source_case_ocels_file_id: &str,
 ) -> Result<String, (StatusCode, String)> {
-    let case_notion_file_id = Uuid::new_v4().to_string();
-    let payload = PersistedCaseNotion {
-        case_notion: cases.to_vec(),
-        origin_file_id_ocel: persisted.origin_file_id_ocel.clone(),
-        case_notion_type: persisted.case_notion_type.clone(),
-        object_type: persisted.object_type.clone(),
-        case_notion_file_id: case_notion_file_id.clone(),
-    };
+    let case_ocels_file_id = Uuid::new_v4().to_string();
 
-    let data = serde_json::to_vec(&payload).map_err(|err| {
-        eprintln!("serialize filtered case notion failed: {err}");
+    let selected: Vec<&OCEL> = kept_indices
+        .iter()
+        .map(|&index| &collection.ocels[index])
+        .collect();
+
+    let mut payload: serde_json::Map<String, Value> =
+        collection.attributes.clone().into_iter().collect();
+    payload.insert(
+        "source_case_ocels_file_id".to_string(),
+        Value::String(source_case_ocels_file_id.to_string()),
+    );
+    payload.insert("filtered_by_kpi_histogram".to_string(), Value::Bool(true));
+
+    let case_ocels_value = serde_json::to_value(&selected).map_err(|err| {
+        eprintln!("serialize filtered case OCELs failed: {err}");
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to serialize filtered case notion".to_string(),
+            "Failed to serialize filtered case OCELs".to_string(),
+        )
+    })?;
+    payload.insert("case_ocels".to_string(), case_ocels_value);
+
+    let data = serde_json::to_vec(&Value::Object(payload)).map_err(|err| {
+        eprintln!("serialize filtered case OCEL collection failed: {err}");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to serialize filtered case OCEL collection".to_string(),
         )
     })?;
 
-    let path = format!("./temp/case_notion_{}.json", case_notion_file_id);
+    let path = format!("./temp/case_ocels_{}.json", case_ocels_file_id);
     tokio_fs::write(&path, data).await.map_err(|err| {
-        eprintln!("write filtered case notion failed: {err}");
+        eprintln!("write filtered case OCEL collection failed: {err}");
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to persist filtered case notion".to_string(),
+            "Failed to persist filtered case OCEL collection".to_string(),
         )
     })?;
 
-    Ok(case_notion_file_id)
+    Ok(case_ocels_file_id)
 }
 
-/// POST /v1/kpi/histogram_filter/{case_notion_file_id}
+/// POST /v1/kpi/histogram_filter/{case_ocels_file_id}
 /// Body: KPI histogram filter with value ranges from selected bins.
-/// Returns: new case notion file id.
+/// Returns: new case OCEL collection file id.
 pub async fn post_kpi_histogram_filter(
-    Path(case_notion_file_id): Path<String>,
+    Path(case_ocels_file_id): Path<String>,
     Json(payload): Json<KpiHistogramFilterPayload>,
 ) -> impl IntoResponse {
-    let ctx = match load_kpi_context(&case_notion_file_id).await {
+    let ctx = match load_kpi_context(&case_ocels_file_id).await {
         Ok(ctx) => ctx,
         Err(response) => return response,
     };
-    let (event_lookup, object_lookup) = ocel_lookups(&ctx.ocel);
 
-    let filtered_cases = match filter_case_notion_by_kpi_histogram(
-        &ctx.persisted.case_notion,
-        &event_lookup,
-        &object_lookup,
-        &payload,
-    ) {
-        Ok(cases) => cases,
-        Err(message) => return (StatusCode::BAD_REQUEST, message).into_response(),
-    };
+    let kept_indices =
+        match filter_case_indices_by_kpi_histogram(&ctx.collection.ocels, &payload) {
+            Ok(indices) => indices,
+            Err(message) => return (StatusCode::BAD_REQUEST, message).into_response(),
+        };
 
-    match persist_filtered_case_notion(&filtered_cases, &ctx.persisted).await {
+    match persist_filtered_case_ocels(&ctx.collection, &kept_indices, &case_ocels_file_id).await {
         Ok(id) => (StatusCode::OK, Json(id)).into_response(),
         Err((status, message)) => (status, message).into_response(),
     }

--- a/backend/src/models/kpi.rs
+++ b/backend/src/models/kpi.rs
@@ -32,7 +32,7 @@ pub struct OcelMetadataResponse {
     pub event_types: Vec<EventTypeMetadata>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct NumericStats {
     pub count: usize,
     pub min: f64,
@@ -55,7 +55,7 @@ pub struct CaseAttributeQuery {
 
 #[derive(Serialize, Deserialize)]
 pub struct CaseAttributeStatsResponse {
-    pub case_notion_file_id: String,
+    pub case_ocels_file_id: String,
     pub origin_file_id_ocel: String,
     pub case_notion_type: String,
     pub attribute: String,
@@ -79,7 +79,7 @@ pub enum CombinationOperator {
     Divide,
 }
 
-/// `POST /v1/kpi/attribute_combination/{case_notion_file_id}`
+/// `POST /v1/kpi/attribute_combination/{case_ocels_file_id}`
 /// `left_intra_case_agg` and `right_intra_case_agg` are required.
 #[derive(Deserialize)]
 pub struct CaseAttributeCombinationRequest {
@@ -97,7 +97,7 @@ pub struct CaseAttributeCombinationRequest {
 
 #[derive(Serialize, Deserialize)]
 pub struct CaseAttributeCombinationStatsResponse {
-    pub case_notion_file_id: String,
+    pub case_ocels_file_id: String,
     pub origin_file_id_ocel: String,
     pub case_notion_type: String,
     pub operation: CombinationOperator,
@@ -124,7 +124,7 @@ pub struct KpiHistogramBin {
     pub bin_end: f64,
 }
 
-/// `POST /v1/kpi/histogram_filter/{case_notion_file_id}`
+/// `POST /v1/kpi/histogram_filter/{case_ocels_file_id}`
 #[derive(Deserialize, Debug)]
 pub struct KpiHistogramFilterPayload {
     pub kpi_filter: KpiFilterSpec,
@@ -160,7 +160,7 @@ pub enum KpiFilterSpec {
     },
 }
 
-/// `GET /v1/kpi/case_time_stats/{case_notion_file_id}`
+/// `GET /v1/kpi/case_time_stats/{case_ocels_file_id}`
 #[derive(Deserialize)]
 pub struct CaseTimeQuery {
     pub object_type: String,
@@ -172,7 +172,7 @@ pub struct CaseTimeQuery {
 
 #[derive(Serialize, Deserialize)]
 pub struct CaseTimeStatsResponse {
-    pub case_notion_file_id: String,
+    pub case_ocels_file_id: String,
     pub origin_file_id_ocel: String,
     pub case_notion_type: String,
     pub object_type: String,
@@ -189,7 +189,7 @@ pub struct CaseTimeStatsResponse {
     pub histogram: Option<Vec<KpiHistogramBin>>,
 }
 
-/// `GET /v1/kpi/activity_successors/{case_notion_file_id}`
+/// `GET /v1/kpi/activity_successors/{case_ocels_file_id}`
 /// `object_type` is required — returns only successors within that object type's timelines.
 #[derive(Deserialize)]
 pub struct ActivitySuccessorsQuery {
@@ -198,12 +198,12 @@ pub struct ActivitySuccessorsQuery {
 
 #[derive(Serialize, Deserialize)]
 pub struct ActivitySuccessorsResponse {
-    pub case_notion_file_id: String,
+    pub case_ocels_file_id: String,
     pub case_notion_type: String,
     pub successors: HashMap<String, Vec<String>>,
 }
 
-/// `GET /v1/kpi/case_duration/{case_notion_file_id}`
+/// `GET /v1/kpi/case_duration/{case_ocels_file_id}`
 #[derive(Deserialize)]
 pub struct CaseDurationQuery {
     pub histogram: Option<bool>,
@@ -211,7 +211,7 @@ pub struct CaseDurationQuery {
 
 #[derive(Serialize, Deserialize)]
 pub struct CaseDurationResponse {
-    pub case_notion_file_id: String,
+    pub case_ocels_file_id: String,
     pub origin_file_id_ocel: String,
     pub case_notion_type: String,
     pub cases_with_duration: usize,

--- a/backend/src/models/kpi.rs
+++ b/backend/src/models/kpi.rs
@@ -22,10 +22,10 @@ pub struct EventTypeMetadata {
     pub attributes: Vec<AttributeMetadata>,
 }
 
-/// `GET /v1/kpi/ocel_metadata/{file_id}` — object/event types with their attributes.
+/// `GET /v1/kpi/ocel_metadata/{ocel_file_id}` — object/event types with their attributes.
 #[derive(Serialize, Deserialize)]
 pub struct OcelMetadataResponse {
-    pub file_id: String,
+    pub ocel_file_id: String,
     pub total_events: usize,
     pub total_objects: usize,
     pub object_types: Vec<ObjectTypeMetadata>,

--- a/backend/src/models/kpi.rs
+++ b/backend/src/models/kpi.rs
@@ -32,6 +32,16 @@ pub struct OcelMetadataResponse {
     pub event_types: Vec<EventTypeMetadata>,
 }
 
+/// `GET /v1/kpi/case_ocel_metadata/{case_ocels_file_id}` — types from the case collection only.
+#[derive(Serialize, Deserialize)]
+pub struct CaseOcelMetadataResponse {
+    pub case_ocels_file_id: String,
+    pub total_events: usize,
+    pub total_objects: usize,
+    pub object_types: Vec<ObjectTypeMetadata>,
+    pub event_types: Vec<EventTypeMetadata>,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct NumericStats {
     pub count: usize,

--- a/backend/src/routes/v1/kpi.rs
+++ b/backend/src/routes/v1/kpi.rs
@@ -11,27 +11,27 @@ pub fn router() -> Router {
     Router::new()
         .route("/ocel_metadata/{file_id}", get(get_ocel_metadata))
         .route(
-            "/case_attribute_stats/{case_notion_file_id}",
+            "/case_attribute_stats/{case_ocels_file_id}",
             get(get_case_attribute_stats),
         )
         .route(
-            "/attribute_combination/{case_notion_file_id}",
+            "/attribute_combination/{case_ocels_file_id}",
             post(post_attribute_combination),
         )
         .route(
-            "/case_time_stats/{case_notion_file_id}",
+            "/case_time_stats/{case_ocels_file_id}",
             get(get_case_time_stats),
         )
         .route(
-            "/case_duration/{case_notion_file_id}",
+            "/case_duration/{case_ocels_file_id}",
             get(get_case_duration),
         )
         .route(
-            "/activity_successors/{case_notion_file_id}",
+            "/activity_successors/{case_ocels_file_id}",
             get(get_activity_successors),
         )
         .route(
-            "/histogram_filter/{case_notion_file_id}",
+            "/histogram_filter/{case_ocels_file_id}",
             post(post_kpi_histogram_filter),
         )
 }

--- a/backend/src/routes/v1/kpi.rs
+++ b/backend/src/routes/v1/kpi.rs
@@ -1,6 +1,6 @@
 use crate::handlers::kpi::{
-    get_activity_successors, get_case_attribute_stats, get_case_duration, get_case_time_stats,
-    get_ocel_metadata, post_attribute_combination, post_kpi_histogram_filter,
+    get_activity_successors, get_case_attribute_stats, get_case_duration, get_case_ocel_metadata,
+    get_case_time_stats, get_ocel_metadata, post_attribute_combination, post_kpi_histogram_filter,
 };
 use axum::{
     Router,
@@ -10,6 +10,10 @@ use axum::{
 pub fn router() -> Router {
     Router::new()
         .route("/ocel_metadata/{file_id}", get(get_ocel_metadata))
+        .route(
+            "/case_ocel_metadata/{case_ocels_file_id}",
+            get(get_case_ocel_metadata),
+        )
         .route(
             "/case_attribute_stats/{case_ocels_file_id}",
             get(get_case_attribute_stats),

--- a/backend/src/routes/v1/kpi.rs
+++ b/backend/src/routes/v1/kpi.rs
@@ -9,7 +9,7 @@ use axum::{
 
 pub fn router() -> Router {
     Router::new()
-        .route("/ocel_metadata/{file_id}", get(get_ocel_metadata))
+        .route("/ocel_metadata/{ocel_file_id}", get(get_ocel_metadata))
         .route(
             "/case_ocel_metadata/{case_ocels_file_id}",
             get(get_case_ocel_metadata),

--- a/frontend/src/components/explore/file/OcelCollectionNode.tsx
+++ b/frontend/src/components/explore/file/OcelCollectionNode.tsx
@@ -18,7 +18,7 @@ const OcelCollectionNode = memo<NodeProps<FileNode>>((props) => {
     return (
         <BaseFileNode
             {...props}
-            title="OCEL Collection"
+            title="Case Collection"
             iconName="fileStack"
             handleOptions={[{ id: 'source', position: Position.Right, type: 'source' as const }]}
             dropdownOptions={[{ label: 'Open File', action: 'openFileDialog' as const, icon: 'file' }]}

--- a/frontend/src/lib/iconMap.ts
+++ b/frontend/src/lib/iconMap.ts
@@ -95,7 +95,7 @@ export const ASSET_TYPE_VISUALS: Record<AssetType, AssetTypeVisual> = {
     ocelCollectionFile: {
         icon: FileStack,
         color: 'text-green-500',
-        label: 'OCEL Collection',
+        label: 'Case Collection',
     },
     identityOcptAsset: {
         icon: FileText,


### PR DESCRIPTION
- All KPI calculation endpoints now accept a case_ocel_file_id, and KPI histogram filtering returns the case_ocel_file_id of the newly generated filtered case OCEL. 

- **UI Update:** The OCEL Collection node is now named as Case Collection

- Added a new endpoint to fetch metadata for case OCEL files: **GET /v1/kpi/case_ocel_metadata/{case_ocels_file_id}**. This endpoint should be used to populate the object type and event type dropdowns for KPI calculations. The old endpoint, **GET /v1/kpi/ocel_metadata/{ocel_file_id}**, is still available if needed.

<img width="398" height="127" alt="Ekran görüntüsü 2026-07-15 232444" src="https://github.com/user-attachments/assets/c4d31de4-a6fa-4c04-ab03-1f89f659453c" />
