### PR TITLE
Feature/activity label splitting backend

### DIFF
--- a/backend/src/core/activity_label_splitting/context.rs
+++ b/backend/src/core/activity_label_splitting/context.rs
@@ -1,0 +1,127 @@
+use crate::models::ocel::OCEL;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::BTreeSet;
+
+pub type ActivitySet = BTreeSet<String>;
+pub type ContextBag = Vec<ActivitySet>;
+
+#[derive(Debug, Clone)]
+pub struct EventContext {
+    pub pre: FxHashMap<String, ContextBag>,
+    pub post: FxHashMap<String, ContextBag>,
+}
+
+/// Activity -> object types linked to it.
+pub fn related_types_by_activity(cases: &[OCEL]) -> FxHashMap<String, Vec<String>> {
+    let mut related: FxHashMap<String, BTreeSet<String>> = FxHashMap::default();
+
+    for case in cases {
+        let types = object_type_map(case);
+        for event in &case.events {
+            let entry = related.entry(event.event_type.clone()).or_default();
+            for rel in &event.relationships {
+                if let Some(&ot) = types.get(rel.object_id.as_str()) {
+                    entry.insert(ot.to_string());
+                }
+            }
+        }
+    }
+
+    related
+        .into_iter()
+        .map(|(activity, ots)| (activity, ots.into_iter().collect()))
+        .collect()
+}
+
+fn object_type_map(case: &OCEL) -> FxHashMap<&str, &str> {
+    case.objects
+        .iter()
+        .map(|o| (o.id.as_str(), o.object_type.as_str()))
+        .collect()
+}
+
+fn build_timelines(
+    case: &OCEL,
+) -> FxHashMap<String, Vec<(chrono::DateTime<chrono::FixedOffset>, String, usize)>> {
+    let mut timelines: FxHashMap<
+        String,
+        Vec<(chrono::DateTime<chrono::FixedOffset>, String, usize)>,
+    > = FxHashMap::default();
+
+    for (event_idx, event) in case.events.iter().enumerate() {
+        for rel in &event.relationships {
+            timelines.entry(rel.object_id.clone()).or_default().push((
+                event.time,
+                event.event_type.clone(),
+                event_idx,
+            ));
+        }
+    }
+
+    for timeline in timelines.values_mut() {
+        timeline.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2)));
+    }
+    timelines
+}
+
+/// Prefix/postfix contexts for selected events in a case.
+pub fn case_contexts(
+    case: &OCEL,
+    object_types: &[String],
+    event_indices: &FxHashSet<usize>,
+) -> FxHashMap<usize, EventContext> {
+    if event_indices.is_empty() {
+        return FxHashMap::default();
+    }
+
+    let types = object_type_map(case);
+    let timelines = build_timelines(case);
+    let wanted: FxHashSet<&str> = object_types.iter().map(|s| s.as_str()).collect();
+    let mut out: FxHashMap<usize, EventContext> = FxHashMap::default();
+
+    for &event_idx in event_indices {
+        let Some(event) = case.events.get(event_idx) else {
+            continue;
+        };
+
+        let mut pre: FxHashMap<String, ContextBag> = FxHashMap::default();
+        let mut post: FxHashMap<String, ContextBag> = FxHashMap::default();
+        let mut seen: FxHashSet<&str> = FxHashSet::default();
+
+        for rel in &event.relationships {
+            let object_id = rel.object_id.as_str();
+            if !seen.insert(object_id) {
+                continue;
+            }
+            let Some(&ot) = types.get(object_id) else {
+                continue;
+            };
+            if !wanted.contains(ot) {
+                continue;
+            }
+            let Some(timeline) = timelines.get(object_id) else {
+                continue;
+            };
+
+            let mut before = BTreeSet::new();
+            let mut after = BTreeSet::new();
+            for (time, activity, idx) in timeline {
+                if *idx == event_idx {
+                    continue;
+                }
+                if *time < event.time || (*time == event.time && *idx < event_idx) {
+                    before.insert(activity.clone());
+                } else if *time > event.time || (*time == event.time && *idx > event_idx) {
+                    after.insert(activity.clone());
+                }
+            }
+
+            pre.entry(ot.to_string()).or_default().push(before);
+            post.entry(ot.to_string()).or_default().push(after);
+        }
+
+        out.insert(event_idx, EventContext { pre, post });
+    }
+
+    out
+}

--- a/backend/src/core/activity_label_splitting/dbscan.rs
+++ b/backend/src/core/activity_label_splitting/dbscan.rs
@@ -1,0 +1,58 @@
+/// DBSCAN on a distance matrix. -1 means noise.
+pub fn dbscan(distances: &[Vec<f64>], eps: f64, min_samples: usize) -> Vec<i32> {
+    let n = distances.len();
+    if n == 0 {
+        return Vec::new();
+    }
+
+    let mut labels = vec![-2i32; n]; // not visited yet
+    let mut cluster_id: i32 = 0;
+
+    for i in 0..n {
+        if labels[i] != -2 {
+            continue;
+        }
+
+        let neighbors = region_query(distances, i, eps);
+        if neighbors.len() < min_samples {
+            labels[i] = -1;
+            continue;
+        }
+
+        labels[i] = cluster_id;
+        let mut seeds = neighbors;
+        let mut seed_idx = 0;
+        while seed_idx < seeds.len() {
+            let q = seeds[seed_idx];
+            seed_idx += 1;
+
+            if labels[q] == -1 {
+                labels[q] = cluster_id;
+            }
+            if labels[q] != -2 {
+                continue;
+            }
+
+            labels[q] = cluster_id;
+            let q_neighbors = region_query(distances, q, eps);
+            if q_neighbors.len() >= min_samples {
+                for &j in &q_neighbors {
+                    if !seeds.contains(&j) {
+                        seeds.push(j);
+                    }
+                }
+            }
+        }
+        cluster_id += 1;
+    }
+
+    labels
+}
+
+fn region_query(distances: &[Vec<f64>], i: usize, eps: f64) -> Vec<usize> {
+    distances[i]
+        .iter()
+        .enumerate()
+        .filter_map(|(j, &d)| if d <= eps { Some(j) } else { None })
+        .collect()
+}

--- a/backend/src/core/activity_label_splitting/distance.rs
+++ b/backend/src/core/activity_label_splitting/distance.rs
@@ -1,0 +1,68 @@
+use super::context::{ActivitySet, ContextBag, EventContext};
+
+pub fn jaccard(a: &ActivitySet, b: &ActivitySet) -> f64 {
+    if a.is_empty() && b.is_empty() {
+        return 0.0;
+    }
+    let union = a.union(b).count();
+    let inter = a.intersection(b).count();
+    1.0 - (inter as f64) / (union as f64)
+}
+
+fn avg_jaccard(left: &[ActivitySet], right: &[ActivitySet]) -> f64 {
+    if left.is_empty() && right.is_empty() {
+        return 0.0;
+    }
+    if left.is_empty() || right.is_empty() {
+        return 1.0;
+    }
+    let mut sum = 0.0;
+    for a in left {
+        for b in right {
+            sum += jaccard(a, b);
+        }
+    }
+    sum / ((left.len() * right.len()) as f64)
+}
+
+fn bag_for<'a>(
+    map: &'a rustc_hash::FxHashMap<String, ContextBag>,
+    object_type: &str,
+) -> &'a [ActivitySet] {
+    map.get(object_type).map(Vec::as_slice).unwrap_or(&[])
+}
+
+/// Distance for one object type via prefix/postfix Jaccard.
+pub fn typed_distance(a: &EventContext, b: &EventContext, object_type: &str) -> f64 {
+    0.5 * avg_jaccard(bag_for(&a.pre, object_type), bag_for(&b.pre, object_type))
+        + 0.5 * avg_jaccard(bag_for(&a.post, object_type), bag_for(&b.post, object_type))
+}
+
+/// Mean typed distance over related object types.
+pub fn aggregated_distance(
+    a: &EventContext,
+    b: &EventContext,
+    object_types: &[String],
+) -> f64 {
+    if object_types.is_empty() {
+        return 0.0;
+    }
+    object_types
+        .iter()
+        .map(|ot| typed_distance(a, b, ot))
+        .sum::<f64>()
+        / (object_types.len() as f64)
+}
+
+pub fn distance_matrix(contexts: &[&EventContext], object_types: &[String]) -> Vec<Vec<f64>> {
+    let n = contexts.len();
+    let mut matrix = vec![vec![0.0; n]; n];
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let d = aggregated_distance(contexts[i], contexts[j], object_types);
+            matrix[i][j] = d;
+            matrix[j][i] = d;
+        }
+    }
+    matrix
+}

--- a/backend/src/core/activity_label_splitting/mod.rs
+++ b/backend/src/core/activity_label_splitting/mod.rs
@@ -1,0 +1,6 @@
+mod context;
+mod dbscan;
+mod distance;
+mod split;
+
+pub use split::{SplitParams, split_activity_labels};

--- a/backend/src/core/activity_label_splitting/split.rs
+++ b/backend/src/core/activity_label_splitting/split.rs
@@ -10,6 +10,7 @@ use std::collections::{BTreeMap, BTreeSet};
 pub struct SplitParams {
     pub eps: f64,
     pub min_samples: usize,
+    pub keep_noise: bool,
 }
 
 impl Default for SplitParams {
@@ -17,6 +18,7 @@ impl Default for SplitParams {
         Self {
             eps: 0.3,
             min_samples: 2,
+            keep_noise: false,
         }
     }
 }
@@ -80,6 +82,7 @@ pub fn split_activity_labels(
         .collect();
 
     let mut renames: FxHashMap<(usize, usize), String> = FxHashMap::default();
+    let mut to_delete: FxHashSet<(usize, usize)> = FxHashSet::default();
     let mut summaries: Vec<SplitInfo> = Vec::new();
 
     for (activity, refs) in candidates {
@@ -101,11 +104,13 @@ pub fn split_activity_labels(
         let matrix = distance_matrix(&event_contexts, object_types);
         let labels = dbscan(&matrix, params.eps, params.min_samples);
 
-        // skip noise (-1), only real clusters get renamed
         let mut groups: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
+        let mut noise_members: Vec<usize> = Vec::new();
         for (i, &label) in labels.iter().enumerate() {
             if label >= 0 {
                 groups.entry(label).or_default().push(i);
+            } else if label == -1 {
+                noise_members.push(i);
             }
         }
         if groups.len() < 2 {
@@ -125,14 +130,26 @@ pub fn split_activity_labels(
             }
         }
 
+        // noise: rename to [noise] or mark for deletion
+        let noise_name = format!("{} [noise]", activity);
+        for &member in &noise_members {
+            let r = refs[member];
+            if params.keep_noise {
+                renames.insert((r.case_idx, r.event_idx), noise_name.clone());
+            } else {
+                to_delete.insert((r.case_idx, r.event_idx));
+            }
+        }
+
         summaries.push(SplitInfo {
             activity,
             variants: ordered.len(),
             event_counts,
+            noise_count: noise_members.len(),
         });
     }
 
-    if renames.is_empty() {
+    if renames.is_empty() && to_delete.is_empty() {
         return (Vec::new(), summaries);
     }
 
@@ -149,11 +166,38 @@ pub fn split_activity_labels(
                 event.event_type = name.clone();
             }
         }
+
+        if !to_delete.is_empty() {
+            let mut keep = Vec::with_capacity(case.events.len());
+            for (event_idx, event) in case.events.drain(..).enumerate() {
+                if !to_delete.contains(&(case_idx, event_idx)) {
+                    keep.push(event);
+                }
+            }
+            case.events = keep;
+            prune_unused_objects(case);
+        }
+
         sync_event_types(case, &schema);
     }
 
     summaries.sort_by(|a, b| a.activity.cmp(&b.activity));
     (result, summaries)
+}
+
+fn prune_unused_objects(case: &mut OCEL) {
+    let used_objects: FxHashSet<String> = case
+        .events
+        .iter()
+        .flat_map(|e| e.relationships.iter().map(|r| r.object_id.clone()))
+        .collect();
+    case.objects.retain(|o| used_objects.contains(&o.id));
+    let used_types: FxHashSet<String> = case
+        .objects
+        .iter()
+        .map(|o| o.object_type.clone())
+        .collect();
+    case.object_types.retain(|t| used_types.contains(&t.name));
 }
 
 fn sync_event_types(case: &mut OCEL, schema: &FxHashMap<String, Vec<OCELTypeAttribute>>) {
@@ -175,5 +219,6 @@ fn sync_event_types(case: &mut OCEL, schema: &FxHashMap<String, Vec<OCELTypeAttr
 }
 
 fn base_activity(name: &str) -> Option<&str> {
-    name.rsplit_once(" [variant ").map(|(base, _)| base)
+    name.strip_suffix(" [noise]")
+        .or_else(|| name.rsplit_once(" [variant ").map(|(base, _)| base))
 }

--- a/backend/src/core/activity_label_splitting/split.rs
+++ b/backend/src/core/activity_label_splitting/split.rs
@@ -1,0 +1,179 @@
+use super::context::{EventContext, case_contexts, related_types_by_activity};
+use super::dbscan::dbscan;
+use super::distance::distance_matrix;
+use crate::models::activity_label_splitting::SplitInfo;
+use crate::models::ocel::{OCEL, OCELType, OCELTypeAttribute};
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, Copy)]
+pub struct SplitParams {
+    pub eps: f64,
+    pub min_samples: usize,
+}
+
+impl Default for SplitParams {
+    fn default() -> Self {
+        Self {
+            eps: 0.3,
+            min_samples: 2,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct EventRef {
+    case_idx: usize,
+    event_idx: usize,
+}
+
+/// Split same-activity events by context into `"act [variant n]"`.
+/// If nothing splits, cases vec is empty.
+pub fn split_activity_labels(
+    cases: &[OCEL],
+    params: SplitParams,
+) -> (Vec<OCEL>, Vec<SplitInfo>) {
+    // group events by activity name
+    let mut by_activity: BTreeMap<String, Vec<EventRef>> = BTreeMap::new();
+    for (case_idx, case) in cases.iter().enumerate() {
+        for (event_idx, event) in case.events.iter().enumerate() {
+            by_activity
+                .entry(event.event_type.clone())
+                .or_default()
+                .push(EventRef {
+                    case_idx,
+                    event_idx,
+                });
+        }
+    }
+
+    // skip activities that appear only once
+    let candidates: Vec<(String, Vec<EventRef>)> = by_activity
+        .into_iter()
+        .filter(|(_, refs)| refs.len() >= 2)
+        .collect();
+
+    if candidates.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+
+    let related_by_activity = related_types_by_activity(cases);
+
+    let all_object_types: Vec<String> = cases
+        .iter()
+        .flat_map(|c| c.object_types.iter().map(|t| t.name.clone()))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    // only build prefix/postfix for candidate events
+    let mut needed: Vec<FxHashSet<usize>> = vec![FxHashSet::default(); cases.len()];
+    for (_, refs) in &candidates {
+        for r in refs {
+            needed[r.case_idx].insert(r.event_idx);
+        }
+    }
+    let contexts: Vec<FxHashMap<usize, EventContext>> = cases
+        .iter()
+        .enumerate()
+        .map(|(case_idx, case)| case_contexts(case, &all_object_types, &needed[case_idx]))
+        .collect();
+
+    let mut renames: FxHashMap<(usize, usize), String> = FxHashMap::default();
+    let mut summaries: Vec<SplitInfo> = Vec::new();
+
+    for (activity, refs) in candidates {
+        let Some(object_types) = related_by_activity.get(&activity) else {
+            continue;
+        };
+        if object_types.is_empty() {
+            continue;
+        }
+
+        let event_contexts: Vec<&EventContext> = refs
+            .iter()
+            .filter_map(|r| contexts[r.case_idx].get(&r.event_idx))
+            .collect();
+        if event_contexts.len() != refs.len() {
+            continue;
+        }
+
+        let matrix = distance_matrix(&event_contexts, object_types);
+        let labels = dbscan(&matrix, params.eps, params.min_samples);
+
+        // skip noise (-1), only real clusters get renamed
+        let mut groups: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
+        for (i, &label) in labels.iter().enumerate() {
+            if label >= 0 {
+                groups.entry(label).or_default().push(i);
+            }
+        }
+        if groups.len() < 2 {
+            continue;
+        }
+
+        let mut ordered: Vec<(i32, Vec<usize>)> = groups.into_iter().collect();
+        ordered.sort_by(|a, b| b.1.len().cmp(&a.1.len()).then_with(|| a.1[0].cmp(&b.1[0])));
+
+        let mut event_counts = Vec::with_capacity(ordered.len());
+        for (variant, (_id, members)) in ordered.iter().enumerate() {
+            let name = format!("{} [variant {}]", activity, variant + 1);
+            event_counts.push(members.len());
+            for &member in members {
+                let r = refs[member];
+                renames.insert((r.case_idx, r.event_idx), name.clone());
+            }
+        }
+
+        summaries.push(SplitInfo {
+            activity,
+            variants: ordered.len(),
+            event_counts,
+        });
+    }
+
+    if renames.is_empty() {
+        return (Vec::new(), summaries);
+    }
+
+    let mut result = cases.to_vec();
+    for (case_idx, case) in result.iter_mut().enumerate() {
+        let schema: FxHashMap<String, Vec<OCELTypeAttribute>> = case
+            .event_types
+            .iter()
+            .map(|t| (t.name.clone(), t.attributes.clone()))
+            .collect();
+
+        for (event_idx, event) in case.events.iter_mut().enumerate() {
+            if let Some(name) = renames.get(&(case_idx, event_idx)) {
+                event.event_type = name.clone();
+            }
+        }
+        sync_event_types(case, &schema);
+    }
+
+    summaries.sort_by(|a, b| a.activity.cmp(&b.activity));
+    (result, summaries)
+}
+
+fn sync_event_types(case: &mut OCEL, schema: &FxHashMap<String, Vec<OCELTypeAttribute>>) {
+    let used: BTreeSet<String> = case.events.iter().map(|e| e.event_type.clone()).collect();
+    case.event_types = used
+        .into_iter()
+        .map(|name| {
+            let attrs = schema
+                .get(&name)
+                .cloned()
+                .or_else(|| base_activity(&name).and_then(|b| schema.get(b).cloned()))
+                .unwrap_or_default();
+            OCELType {
+                name,
+                attributes: attrs,
+            }
+        })
+        .collect();
+}
+
+fn base_activity(name: &str) -> Option<&str> {
+    name.rsplit_once(" [variant ").map(|(base, _)| base)
+}

--- a/backend/src/core/mod.rs
+++ b/backend/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod activity_label_splitting;
 pub mod case_notion;
 pub mod clustering;
 pub mod df2_miner;

--- a/backend/src/handlers/activity_label_splitting.rs
+++ b/backend/src/handlers/activity_label_splitting.rs
@@ -1,0 +1,152 @@
+use crate::core::activity_label_splitting::{SplitParams, split_activity_labels};
+use crate::models::activity_label_splitting::{SplitQuery, SplitResponse};
+use crate::models::ocel_collection::OCELCollection;
+use crate::traits::import_export::ImportableFromPath;
+use axum::{
+    Json,
+    extract::{Path, Query},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::Value;
+use tokio::fs as tokio_fs;
+use uuid::Uuid;
+
+/// POST /v1/activity_label_splitting/{case_ocels_file_id}
+pub async fn post_activity_label_split(
+    Path(file_id): Path<String>,
+    Query(query): Query<SplitQuery>,
+) -> impl IntoResponse {
+    let collection = match OCELCollection::import_from_path(&file_id).await {
+        Ok(c) => c,
+        Err((status, _)) if status == StatusCode::NOT_FOUND => {
+            return (
+                StatusCode::NOT_FOUND,
+                format!("No stored case OCEL collection found for fileId: {file_id}"),
+            )
+                .into_response();
+        }
+        Err((status, msg)) => return (status, msg).into_response(),
+    };
+
+    let defaults = SplitParams::default();
+    let params = SplitParams {
+        eps: query.eps.unwrap_or(defaults.eps),
+        min_samples: query.min_samples.unwrap_or(defaults.min_samples),
+    };
+
+    if !(params.eps > 0.0 && params.eps <= 1.0) {
+        return (StatusCode::BAD_REQUEST, "eps must be in (0, 1]".to_string()).into_response();
+    }
+    if params.min_samples < 2 {
+        return (
+            StatusCode::BAD_REQUEST,
+            "min_samples must be >= 2".to_string(),
+        )
+            .into_response();
+    }
+
+    let ocels = collection.ocels;
+    let attrs = collection.attributes;
+
+    let joined =
+        tokio::task::spawn_blocking(move || split_activity_labels(&ocels, params)).await;
+    let (split_ocels, summaries) = match joined {
+        Ok(r) => r,
+        Err(err) => {
+            eprintln!("activity label splitting join failed: {err}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Activity label splitting failed".to_string(),
+            )
+                .into_response();
+        }
+    };
+
+    if summaries.is_empty() {
+        return (
+            StatusCode::OK,
+            Json(SplitResponse {
+                case_ocels_file_id: file_id.clone(),
+                source_case_ocels_file_id: file_id,
+                splitting_applied: false,
+                splits: summaries,
+            }),
+        )
+            .into_response();
+    }
+
+    let out = OCELCollection {
+        ocels: split_ocels,
+        attributes: attrs,
+    };
+
+    match persist_split_cases(&out, &file_id, params).await {
+        Ok(new_id) => (
+            StatusCode::OK,
+            Json(SplitResponse {
+                case_ocels_file_id: new_id,
+                source_case_ocels_file_id: file_id,
+                splitting_applied: true,
+                splits: summaries,
+            }),
+        )
+            .into_response(),
+        Err((status, msg)) => (status, msg).into_response(),
+    }
+}
+
+async fn persist_split_cases(
+    collection: &OCELCollection,
+    source_id: &str,
+    params: SplitParams,
+) -> Result<String, (StatusCode, String)> {
+    let id = Uuid::new_v4().to_string();
+
+    let mut payload: serde_json::Map<String, Value> =
+        collection.attributes.clone().into_iter().collect();
+    payload.insert(
+        "source_case_ocels_file_id".to_string(),
+        Value::String(source_id.to_string()),
+    );
+    payload.insert(
+        "activity_label_splitting_applied".to_string(),
+        Value::Bool(true),
+    );
+    payload.insert(
+        "activity_label_splitting_eps".to_string(),
+        Value::from(params.eps),
+    );
+    payload.insert(
+        "activity_label_splitting_min_samples".to_string(),
+        Value::from(params.min_samples as u64),
+    );
+
+    let cases = serde_json::to_value(&collection.ocels).map_err(|err| {
+        eprintln!("serialize split cases failed: {err}");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to serialize split case OCELs".to_string(),
+        )
+    })?;
+    payload.insert("case_ocels".to_string(), cases);
+
+    let bytes = serde_json::to_vec(&Value::Object(payload)).map_err(|err| {
+        eprintln!("serialize split collection failed: {err}");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to serialize split case OCEL collection".to_string(),
+        )
+    })?;
+
+    let path = format!("./temp/case_ocels_{id}.json");
+    tokio_fs::write(&path, bytes).await.map_err(|err| {
+        eprintln!("write split collection failed: {err}");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to persist split case OCEL collection".to_string(),
+        )
+    })?;
+
+    Ok(id)
+}

--- a/backend/src/handlers/activity_label_splitting.rs
+++ b/backend/src/handlers/activity_label_splitting.rs
@@ -29,10 +29,21 @@ pub async fn post_activity_label_split(
         Err((status, msg)) => return (status, msg).into_response(),
     };
 
+    if already_split(&collection) {
+        return (
+            StatusCode::BAD_REQUEST,
+            "Activity label splitting was already applied to this case OCEL collection. \
+Use the original (pre-split) collection instead."
+                .to_string(),
+        )
+            .into_response();
+    }
+
     let defaults = SplitParams::default();
     let params = SplitParams {
         eps: query.eps.unwrap_or(defaults.eps),
         min_samples: query.min_samples.unwrap_or(defaults.min_samples),
+        keep_noise: query.keep_noise.unwrap_or(defaults.keep_noise),
     };
 
     if !(params.eps > 0.0 && params.eps <= 1.0) {
@@ -70,11 +81,14 @@ pub async fn post_activity_label_split(
                 case_ocels_file_id: file_id.clone(),
                 source_case_ocels_file_id: file_id,
                 splitting_applied: false,
+                noise_detected: false,
                 splits: summaries,
             }),
         )
             .into_response();
     }
+
+    let noise_detected = summaries.iter().any(|s| s.noise_count > 0);
 
     let out = OCELCollection {
         ocels: split_ocels,
@@ -88,6 +102,7 @@ pub async fn post_activity_label_split(
                 case_ocels_file_id: new_id,
                 source_case_ocels_file_id: file_id,
                 splitting_applied: true,
+                noise_detected,
                 splits: summaries,
             }),
         )
@@ -121,6 +136,10 @@ async fn persist_split_cases(
         "activity_label_splitting_min_samples".to_string(),
         Value::from(params.min_samples as u64),
     );
+    payload.insert(
+        "activity_label_splitting_keep_noise".to_string(),
+        Value::Bool(params.keep_noise),
+    );
 
     let cases = serde_json::to_value(&collection.ocels).map_err(|err| {
         eprintln!("serialize split cases failed: {err}");
@@ -149,4 +168,26 @@ async fn persist_split_cases(
     })?;
 
     Ok(id)
+}
+
+fn already_split(collection: &OCELCollection) -> bool {
+    if collection
+        .attributes
+        .get("activity_label_splitting_applied")
+        .and_then(|v| v.as_bool())
+        == Some(true)
+    {
+        return true;
+    }
+
+    collection.ocels.iter().any(|case| {
+        case.event_types
+            .iter()
+            .any(|t| is_split_label(&t.name))
+            || case.events.iter().any(|e| is_split_label(&e.event_type))
+    })
+}
+
+fn is_split_label(name: &str) -> bool {
+    name.contains(" [variant ") || name.ends_with(" [noise]")
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod abstractions;
+pub mod activity_label_splitting;
 pub mod case_notion;
 pub mod clustering;
 pub mod collection_ocels;

--- a/backend/src/handlers/ocel.rs
+++ b/backend/src/handlers/ocel.rs
@@ -19,6 +19,27 @@ fn is_ocel_v2(v: &Value) -> bool {
     v.get("objectTypes").is_some() && v.get("eventTypes").is_some()
 }
 
+/// Replace null/missing relationship qualifiers with "" so OCEL deserialization succeeds.
+fn normalize_null_qualifiers(value: &mut Value) {
+    for key in ["events", "objects"] {
+        let Some(items) = value.get_mut(key).and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+        for item in items {
+            let Some(rels) = item.get_mut("relationships").and_then(|v| v.as_array_mut()) else {
+                continue;
+            };
+            for rel in rels {
+                if let Some(obj) = rel.as_object_mut() {
+                    if matches!(obj.get("qualifier"), Some(Value::Null) | None) {
+                        obj.insert("qualifier".to_string(), Value::String(String::new()));
+                    }
+                }
+            }
+        }
+    }
+}
+
 async fn ensure_temp_dir() -> Result<(), std::io::Error> {
     fs::create_dir_all("./temp").await
 }
@@ -35,6 +56,8 @@ pub async fn post_ocel_json(Json(payload): Json<Value>) -> impl IntoResponse {
             .into_response();
     }
 
+    let mut payload = payload;
+
     // Normalize into OCEL (v2 struct)
     let ocel_struct: OCEL = if is_ocel_v1(&payload) {
         match ocel_1_ocel_2_converter::convert_ocel1_value_to_ocel(&payload) {
@@ -46,7 +69,7 @@ pub async fn post_ocel_json(Json(payload): Json<Value>) -> impl IntoResponse {
             }
         }
     } else if is_ocel_v2(&payload) {
-        // Validate/normalize the v2 by parsing into OCEL
+        normalize_null_qualifiers(&mut payload);
         match serde_json::from_value::<OCEL>(payload) {
             Ok(oc) => oc,
             Err(e) => {
@@ -130,7 +153,7 @@ pub async fn post_ocel_binary(mut multipart: Multipart) -> impl IntoResponse {
             return (StatusCode::BAD_REQUEST, "File is not valid UTF-8").into_response();
         }
     };
-    let value: Value = match serde_json::from_str(text) {
+    let mut value: Value = match serde_json::from_str(text) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("❌ Invalid JSON: {e}");
@@ -158,6 +181,7 @@ pub async fn post_ocel_binary(mut multipart: Multipart) -> impl IntoResponse {
             }
         }
     } else if is_ocel_v2(&value) {
+        normalize_null_qualifiers(&mut value);
         match serde_json::from_value::<OCEL>(value) {
             Ok(oc) => oc,
             Err(e) => {

--- a/backend/src/models/activity_label_splitting.rs
+++ b/backend/src/models/activity_label_splitting.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 pub struct SplitQuery {
     pub eps: Option<f64>,
     pub min_samples: Option<usize>,
+    /// If true, noise is renamed to `activity [noise]`; if false (default), noise events are deleted.
+    pub keep_noise: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -11,6 +13,7 @@ pub struct SplitInfo {
     pub activity: String,
     pub variants: usize,
     pub event_counts: Vec<usize>,
+    pub noise_count: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -18,5 +21,6 @@ pub struct SplitResponse {
     pub case_ocels_file_id: String,
     pub source_case_ocels_file_id: String,
     pub splitting_applied: bool,
+    pub noise_detected: bool,
     pub splits: Vec<SplitInfo>,
 }

--- a/backend/src/models/activity_label_splitting.rs
+++ b/backend/src/models/activity_label_splitting.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub struct SplitQuery {
+    pub eps: Option<f64>,
+    pub min_samples: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SplitInfo {
+    pub activity: String,
+    pub variants: usize,
+    pub event_counts: Vec<usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SplitResponse {
+    pub case_ocels_file_id: String,
+    pub source_case_ocels_file_id: String,
+    pub splitting_applied: bool,
+    pub splits: Vec<SplitInfo>,
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod abstraction;
+pub mod activity_label_splitting;
 pub mod case_notion;
 pub mod clustering;
 pub mod dfg;

--- a/backend/src/routes/v1/activity_label_splitting.rs
+++ b/backend/src/routes/v1/activity_label_splitting.rs
@@ -1,0 +1,6 @@
+use crate::handlers::activity_label_splitting::post_activity_label_split;
+use axum::{Router, routing::post};
+
+pub fn router() -> Router {
+    Router::new().route("/{case_ocels_file_id}", post(post_activity_label_split))
+}

--- a/backend/src/routes/v1/mod.rs
+++ b/backend/src/routes/v1/mod.rs
@@ -1,4 +1,5 @@
 pub mod abstractions;
+pub mod activity_label_splitting;
 pub mod case_notion;
 pub mod clustering;
 pub mod conformance;
@@ -39,4 +40,5 @@ pub fn router() -> Router {
         .nest("/event_stream", event_stream_mining::router())
         .nest("/resource_miner", resource_miner::router())
         .nest("/kpi", kpi::router())
+        .nest("/activity_label_splitting", activity_label_splitting::router())
 }


### PR DESCRIPTION
**Endpoint: POST /v1/activity_label_splitting/{case_ocels_file_id}**

- Query: eps (default 0.3), min_samples (default 2), keep_noise (default false)

- Noise: delete events (keep_noise=false) or rename to activity [noise] (keep_noise=true)

- Returns new case OCEL file id + split summary

- Rejects collections that were already split

-  In addition to activity label splitting, i have added a function named normalize_null_qualifiers to backend/src/handlers/ocel.rs file. The file that Niklas suggested for us to work on had null qualifiers and current handling gave errors with it.
 
**A request and response example below:**

- POST v1/activity_label_splitting/case_ocel_file_id?eps=0.2&min_samples=4&keep_noise=false" `

```
{
    "case_ocels_file_id":  "b85be6ef-e5e7-411c-8769-ffad6e3174d2",
    "source_case_ocels_file_id":  "446768e8-f013-4761-8e2d-04bbf27905f5",
    "splitting_applied":  true,
    "noise_detected":  true,
    "splits":  [
                   {
                       "activity":  "assign vacancy",
                       "variants":  2,
                       "event_counts":  [
                                            445,
                                            13
                                        ],
                       "noise_count":  0
                   },
                   {
                       "activity":  "close vacancy for new applications",
                       "variants":  2,
                       "event_counts":  [
                                            127,
                                            4
                                        ],
                       "noise_count":  9
                   },
                   {
                       "activity":  "make job offer",
                       "variants":  2,
                       "event_counts":  [
                                            89,
                                            46
                                        ],
                       "noise_count":  0
                   },
                   {
                       "activity":  "open vacancy",
                       "variants":  2,
                       "event_counts":  [
                                            134,
                                            6
                                        ],
                       "noise_count":  0
                   },
                   {
                       "activity":  "submit application",
                       "variants":  2,
                       "event_counts":  [
                                            458,
                                            458
                                        ],
                       "noise_count":  0
                   }
               ]
}

```